### PR TITLE
Added even more PICA libraries

### DIFF
--- a/assets/bibs/Berlin_StaBi.json
+++ b/assets/bibs/Berlin_StaBi.json
@@ -1,0 +1,16 @@
+﻿{
+    "api": "pica",
+    "city": "Berlin",
+    "data": {
+        "baseurl": "http://stabikat.de/",
+        "information": "http://staatsbibliothek-berlin.de/",
+        "db": "1"
+    },
+    "geo": [
+        52.5089536,
+        13.3710152
+    ],
+    "group": "Berlin",
+    "support": "Katalogsuche",
+    "title": "Staatsbibliothek"
+}

--- a/assets/bibs/Braunschweig_TU.json
+++ b/assets/bibs/Braunschweig_TU.json
@@ -1,0 +1,16 @@
+﻿{
+    "api": "pica",
+    "city": "Braunschweig",
+    "data": {
+        "baseurl": "http://sunny.biblio.etc.tu-bs.de:8080/",
+        "information": "http://www.biblio.tu-bs.de/",
+        "db": "1"
+    },
+    "geo": [
+        52.27387,
+        10.52911
+    ],
+    "group": "Niedersachsen",
+    "support": "Katalogsuche",
+    "title": "Universitätsbibliothek"
+}

--- a/assets/bibs/Halle_Uni.json
+++ b/assets/bibs/Halle_Uni.json
@@ -1,0 +1,16 @@
+﻿{
+    "api": "pica",
+    "city": "Halle (Saale)",
+    "data": {
+        "baseurl": "https://opac.bibliothek.uni-halle.de/",
+        "information": "http://bibliothek.uni-halle.de/",
+        "db": "1"
+    },
+    "geo": [
+        51.4887849,
+        11.970509
+    ],
+    "group": "Sachsen-Anhalt",
+    "support": "Katalogsuche",
+    "title": "Unibibliothek"
+}

--- a/assets/bibs/Hamburg_HSU.json
+++ b/assets/bibs/Hamburg_HSU.json
@@ -1,0 +1,16 @@
+﻿{
+    "api": "pica",
+    "city": "Hamburg",
+    "data": {
+        "baseurl": "http://ub.hsu-hh.de/",
+        "information": "http://ub.hsu-hh.de/",
+        "db": "1"
+    },
+    "geo": [
+        53.56882,
+        10.10725
+    ],
+    "group": "Hamburg",
+    "support": "Katalogsuche",
+    "title": "Bibliothek der Helmut-Schmidt-Universität"
+}

--- a/assets/bibs/Jena_ULB.json
+++ b/assets/bibs/Jena_ULB.json
@@ -1,0 +1,16 @@
+﻿{
+    "api": "pica",
+    "city": "Jena",
+    "data": {
+        "baseurl": "http://kataloge.thulb.uni-jena.de/",
+        "information": "http://www.thulb.uni-jena.de/",
+        "db": "1"
+    },
+    "geo": [
+        50.9306975,
+        11.5880013
+    ],
+    "group": "Thüringen",
+    "support": "Katalogsuche",
+    "title": "Universitäts- und Landesbibliothek"
+}

--- a/assets/bibs/Lueneburg_Uni.json
+++ b/assets/bibs/Lueneburg_Uni.json
@@ -1,0 +1,16 @@
+﻿{
+    "api": "pica",
+    "city": "Lüneburg",
+    "data": {
+        "baseurl": "http://opac.ub.uni-lueneburg.de/",
+        "information": "http://www.leuphana.de/bibliothek.html",
+        "db": "1"
+    },
+    "geo": [
+        53.2296879,
+        10.4019633
+    ],
+    "group": "Niedersachsen",
+    "support": "Katalogsuche",
+    "title": "Unibibliothek"
+}

--- a/assets/bibs/Magdeburg_Uni.json
+++ b/assets/bibs/Magdeburg_Uni.json
@@ -1,0 +1,16 @@
+﻿{
+    "api": "pica",
+    "city": "Magdeburg",
+    "data": {
+        "baseurl": "https://opac.uni-magdeburg.de/",
+        "information": "http://www.ub.ovgu.de/",
+        "db": "1"
+    },
+    "geo": [
+        52.139144,
+        11.6409926
+    ],
+    "group": "Sachsen-Anhalt",
+    "support": "Katalogsuche",
+    "title": "Universitätsbibliothek"
+}

--- a/assets/bibs/Rostock_Uni.json
+++ b/assets/bibs/Rostock_Uni.json
@@ -1,0 +1,16 @@
+﻿{
+    "api": "pica",
+    "city": "Rostock",
+    "data": {
+        "baseurl": "http://katalog.ub.uni-rostock.de/",
+        "information": "http://www.ub.uni-rostock.de/",
+        "db": "1"
+    },
+    "geo": [
+        54.07613,
+        12.10484
+    ],
+    "group": "Mecklenburg-Vorpommern",
+    "support": "Katalogsuche",
+    "title": "Unibibliothek/Regionalkatalog"
+}


### PR DESCRIPTION
I added some more PICA libraries found with Google (http://goo.gl/tjvbQC). Encoding should be right with these, I found the option in Notepad++ to change it to UTF-8.
- Staatsbibliothek Berlin
- TU Braunschweig
- UB Halle
- UB Hamburg (Helmut-Schmidt-Universität)
- ULB Jena
- UB Lüneburg
- UB Magdeburg
- UB/Regionalkatalog Rostock

I left out the libaries that didn't work (e.g. Marburg), I think I won't have the time to fix those in the Java code.
