### PR TITLE
Fixed a bug with IOpac

### DIFF
--- a/src/de/geeksfactory/opacclient/apis/IOpac.java
+++ b/src/de/geeksfactory/opacclient/apis/IOpac.java
@@ -548,8 +548,7 @@ public class IOpac extends BaseApi implements OpacApi {
 
 	protected void parse_medialist(List<ContentValues> medien, Document doc,
 			int offset) throws ClientProtocolException, IOException {
-		Elements copytrs = doc.select("a[name=AUS] ~ table").first()
-				.select("tr");
+		Elements copytrs = doc.select("a[name=AUS] ~ table tr");
 		doc.setBaseUri(opac_url);
 
 		SimpleDateFormat sdf = new SimpleDateFormat("dd.MM.yyyy");


### PR DESCRIPTION
The app crashed when there was no lent media in Schleswig library because it didn't find a table on the account page.
