### PR TITLE
Fix bug in iOPAC

### DIFF
--- a/src/de/geeksfactory/opacclient/apis/IOpac.java
+++ b/src/de/geeksfactory/opacclient/apis/IOpac.java
@@ -46,7 +46,6 @@ import org.jsoup.select.Elements;
 
 import android.content.ContentValues;
 import android.os.Bundle;
-import android.util.Log;
 import de.geeksfactory.opacclient.NotReachableException;
 import de.geeksfactory.opacclient.objects.Account;
 import de.geeksfactory.opacclient.objects.AccountData;


### PR DESCRIPTION
When the search returned for example "240 results", the String on the page also _contained_ "0 results", so nothing was shown. Now it uses _startsWith()_ instead of _contains()_.
