### PR TITLE
accounttable changed in Essen

### DIFF
--- a/assets/bibs/Essen.json
+++ b/assets/bibs/Essen.json
@@ -4,14 +4,14 @@
     "country": "Deutschland", 
     "data": {
         "accounttable": {
-            "author": 6, 
+            "author": 7, 
             "barcode": 3, 
             "homebranch": -1, 
-            "lendingbranch": -1, 
-            "prolongurl": 3, 
+            "lendingbranch": 4, 
+            "prolongurl": 0, 
             "returndate": 2, 
-            "status": 4, 
-            "title": 6
+            "status": 8, 
+            "title": 7
         }, 
         "baseurl": "http://katalog.stadtbibliothek-essen.de", 
         "information": "http://www.stadtbibliothek-essen.de/de/oeffnungszeiten/oeffnungszeiten.html", 


### PR DESCRIPTION
Essen probably changed something on its account table layout (according to a screenshot) so that the title wasn't correctly displayed anymore
