### PR TITLE
Remove unneeded Maven repositories

### DIFF
--- a/opacclient/build.gradle
+++ b/opacclient/build.gradle
@@ -2,8 +2,6 @@
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
-        maven { url = 'http://oss.sonatype.org/content/repositories/releases/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
@@ -13,8 +11,5 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven {
-            url 'https://dl.bintray.com/opacapp/libs/'
-        }
     }
 }


### PR DESCRIPTION
* Maven Central and oss.sonatype are not needed for the dependencies we use.
* The multilinecollapsingtoolbar library is now available on JCenter.