### PR TITLE
IOpac: getSearchFields media types fix

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/IOpac.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/IOpac.java
@@ -984,7 +984,11 @@ public class IOpac extends BaseApi implements OpacApi {
 
         DropdownSearchField mtyp = new DropdownSearchField();
         try {
-            html = httpGet(opac_url + dir + "/mtyp.js", getDefaultEncoding());
+            try {
+                html = httpGet(opac_url + dir + "/mtyp.js", getDefaultEncoding());
+            } catch (NotReachableException e) {
+                html = httpGet(opac_url + "/mtyp.js", getDefaultEncoding());
+            }
 
             String[] parts = html.split("new Array\\(\\);");
             for (String part : parts) {
@@ -1018,7 +1022,7 @@ public class IOpac extends BaseApi implements OpacApi {
             }
 
         }
-        if (!mtyp.getDropdownValues().isEmpty()) {
+        if (mtyp.getDropdownValues() != null && !mtyp.getDropdownValues().isEmpty()) {
             mtyp.setDisplayName("Medientypen");
             mtyp.setId("Medientyp");
             fields.add(mtyp);


### PR DESCRIPTION
In Glückstadt, mtyp.js is not in the "iopac" directory