### PR TITLE
Add README file for libopac

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Support
 -------
 Supports web catalogues of different library system vendors, see our [website](http://de.opacapp.net/kompatibilitaet/) or [wiki](https://github.com/raphaelm/opacclient/wiki/Supported-library-types) for details.
 
+Java Library (`libopac`)
+------------------------
+The underlying code that the app uses to connect to the different supported OPAC software systems and parse data from them is available as a separate library called `libopac`. It can also be used in ordinary Java projects because it does not depend on Android APIs. More information about the library can be found in [its own README file](https://github.com/opacapp/opacclient/blob/master/opacclient/libopac/README.md).
+
 License
 -------
 This code is released under the terms of the [MIT License](http://opensource.org/licenses/mit-license.php)
@@ -35,7 +39,6 @@ It contains several libraries:
 * NineOldAndroids, (c) Jake Wharton, Apache License
 * android-flowlayout, (c) Artem Votincev, Apache License
 * rv-joiner, (c) Evgeny Egorov, Apache License
-
 
 Authors
 -------

--- a/opacclient/libopac/README.md
+++ b/opacclient/libopac/README.md
@@ -6,9 +6,7 @@ Web catalogues of different library system vendors are supported, see our [websi
 
 Installation
 ------------
-The library is available through our [Bintray repository](https://bintray.com/opacapp/libs/libopac/). Snippets for Maven or Gradle build configuration files and JAR downloads are available there.
-
-We also intend to release the library on JCenter soon.
+The library is available through [JCenter](https://bintray.com/opacapp/libs/libopac/). Snippets for Maven or Gradle build configuration files and JAR downloads are available there.
 
 Usage
 -----

--- a/opacclient/libopac/README.md
+++ b/opacclient/libopac/README.md
@@ -1,0 +1,25 @@
+libopac  [ ![Download](https://api.bintray.com/packages/opacapp/libs/libopac/images/download.svg) ](https://bintray.com/opacapp/libs/libopac/_latestVersion)
+=======
+libopac is a Java library that can connect to online catalogs (OPACs) of public libraries and access their search and account data features. It is used by our own [Android app](https://github.com/opacapp/opacclient).
+
+Web catalogues of different library system vendors are supported, see our [website](http://de.opacapp.net/kompatibilitaet/) or [wiki](https://github.com/raphaelm/opacclient/wiki/Supported-library-types) for details.
+
+Installation
+------------
+The library is available through our [Bintray repository](https://bintray.com/opacapp/libs/libopac/). Snippets for Maven or Gradle build configuration files and JAR downloads are available there.
+
+We also intend to release the library on JCenter soon.
+
+Usage
+-----
+The following resources should help you to get started on using libopac:
+
+* [Basic sample project using Maven](https://github.com/opacapp/libopac-sample-mvn) 
+* [Javadoc](https://en.opacapp.net/doc/) (currently outdated)
+* [JSON configuration files](https://github.com/opacapp/opacclient/tree/master/opacclient/opacapp/src/main/assets/bibs) for more than 1000 public and university libraries
+
+If you have any questions, you can write us an email at [info@opacapp.net](mailto:info@opacapp.net).
+
+License
+-------
+Being a part of the [Web Opac App](https://github.com/opacapp/opacclient) project, this code is also licensed under the terms of the [MIT License](http://opensource.org/licenses/mit-license.php).


### PR DESCRIPTION
We should maybe merge this with the next release so that we have some documentation about `libopac` being available as a separate library.