### PR TITLE
WinBiap 4.4 and other fixes, new libraries

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/WinBiap.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/WinBiap.java
@@ -611,6 +611,19 @@ public class WinBiap extends BaseApi implements OpacApi {
             params.add(new BasicNameValuePair(kv.key(), kv.value()));
         }
 
+        if (lentPage.select("a[id$=ButtonBorrowChecked][href^=javascript]").size() > 0) {
+            String href =
+                    lentPage.select("a[id$=ButtonBorrowChecked][href^=javascript]").attr("href");
+            Pattern pattern = Pattern.compile("javascript:__doPostBack\\('([^,]*)','([^\\)]*)'\\)");
+            Matcher matcher = pattern.matcher(href);
+            if (!matcher.find()) {
+                return new ProlongResult(MultiStepResult.Status.ERROR,
+                        StringProvider.INTERNAL_ERROR);
+            }
+            params.add(new BasicNameValuePair("__EVENTTARGET", matcher.group(1)));
+            params.add(new BasicNameValuePair("__EVENTARGUMENT", matcher.group(2)));
+        }
+
         String html = httpPost(opac_url + "/user/borrow.aspx", new UrlEncodedFormEntity
                 (params), getDefaultEncoding());
         Document confirmationPage = Jsoup.parse(html);

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/WinBiap.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/WinBiap.java
@@ -861,6 +861,9 @@ public class WinBiap extends BaseApi implements OpacApi {
                     String base64 = matcher.group(1);
                     item.put(AccountData.KEY_RESERVATION_CANCEL, base64);
                 }
+            } else if (detailsTr.select("input[id*=_hiddenValueDetail][value]").size() > 0) {
+                item.put(AccountData.KEY_RESERVATION_CANCEL,
+                        detailsTr.select("input[id*=_hiddenValueDetail][value]").attr("value"));
             }
             reservations.add(item);
         }

--- a/opacclient/opacapp/src/main/assets/bibs/Baden.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Baden.json
@@ -4,7 +4,7 @@
     "city": "Baden",
     "country": "Schweiz",
     "data": {
-        "baseurl": "http://62.2.168.69/webOPACClient.baden"
+        "baseurl": "http://opac.baden.ch/webOPACClient.baden"
     },
     "geo": [
         47.4737667,

--- a/opacclient/opacapp/src/main/assets/bibs/Buchholz_Nordheide.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Buchholz_Nordheide.json
@@ -1,0 +1,41 @@
+{
+  "account_supported": true,
+  "api": "bibliotheca",
+  "city": "Buchholz in der Nordheide",
+  "country": "Deutschland",
+  "data": {
+    "accounttable": {
+      "author": 0,
+      "prolongurl": 3,
+      "returndate": 2,
+      "title": 1
+    },
+    "baseurl": "http://185.44.4.136/webopac",
+    "copiestable": {
+      "barcode": 0,
+      "branch": 4,
+      "department": 2,
+      "location": 1,
+      "returndate": 5,
+      "status": 3
+    },
+    "mediatypes": {
+      "mCasetteS.gif": "AUDIO_CASSETTE",
+      "mDVDS.gif": "DVD",
+      "mFilmS.gif": "MOVIE"
+    },
+    "reservationtable": {
+      "author": 0,
+      "availability": 2,
+      "cancelurl": 3,
+      "title": 1
+    }
+  },
+  "geo": [
+    53.3176971,
+    9.8694845
+  ],
+  "information": "https://www.buchholz.de/portal/seiten/stadtbuecherei-3000064-20101.html",
+  "state": "Niedersachsen",
+  "title": "Stadtb\u00fccherei"
+}

--- a/opacclient/opacapp/src/main/assets/bibs/Muenchen_Vaterunserkirche.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Muenchen_Vaterunserkirche.json
@@ -1,0 +1,16 @@
+{
+  "account_supported": true,
+  "api": "winbiap",
+  "city": "M\u00fcnchen",
+  "country": "Deutschland",
+  "data": {
+    "baseurl": "https://webopac.winbiap.de/vuk"
+  },
+  "geo": [
+    48.1351253,
+    11.5819806
+  ],
+  "information": "http://www.vaterunserkirche.de/buecherei/",
+  "state": "Bayern",
+  "title": "\u00d6ffentliche B\u00fccherei Vaterunserkirche/St. Thomas"
+}

--- a/opacclient/opacapp/src/main/assets/bibs/Ravensburg_DHBW.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Ravensburg_DHBW.json
@@ -1,0 +1,17 @@
+{
+  "account_supported": true,
+  "api": "adis",
+  "city": "Ravensburg",
+  "country": "Deutschland",
+  "data": {
+    "baseurl": "https://bsz.ibs-bw.de/aDISWeb",
+    "startparams": "service=direct/0/Home/$DirectLink&sp=S127.0.0.1:23122"
+  },
+  "geo": [
+    47.7782704,
+    9.612130299999999
+  ],
+  "information": "http://www.dhbw-ravensburg.de/de/service-einrichtungen/service/kontakt/oeffnungszeiten/",
+  "state": "Baden-W\u00fcrttemberg",
+  "title": "Duale Hochschule"
+}

--- a/opacclient/opacapp/src/main/assets/bibs/Schwaig.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Schwaig.json
@@ -1,0 +1,16 @@
+{
+  "account_supported": true,
+  "api": "winbiap",
+  "city": "Schwaig",
+  "country": "Deutschland",
+  "data": {
+    "baseurl": "https://opac.winbiap.net/schwaig"
+  },
+  "geo": [
+    49.4718884,
+    11.199634
+  ],
+  "information": "http://www.schwaig.de/seite/de/gemeinde/036:71/-/Gemeindebuecherei.html",
+  "state": "Bayern",
+  "title": "Gemeindeb\u00fccherei"
+}

--- a/opacclient/opacapp/src/main/assets/bibs/Trier.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Trier.json
@@ -1,43 +1,20 @@
 {
-    "account_supported": true,
-    "api": "bibliotheca",
+    "account_supported": false,
+    "api": "open",
     "city": "Trier",
     "country": "Deutschland",
     "data": {
-        "accounttable": {
-            "author": 0,
-            "barcode": -1,
-            "homebranch": 3,
-            "lendingbranch": 3,
-            "prolongurl": 4,
-            "returndate": 2,
-            "status": -1,
-            "title": 1
-        },
-        "baseurl": "https://opac.trier.de/webopac",
-        "copiestable": {
-            "barcode": -1,
-            "branch": -1,
-            "department": -1,
-            "location": 3,
-            "reservations": -1,
-            "returndate": 4,
-            "status": 0
-        },
-        "reservationtable": {
-            "author": 0,
-            "availability": 2,
-            "branch": 3,
-            "cancelurl": 4,
-            "expirationdate": null,
-            "title": 1
+        "baseurl": "https://opac.trier.de",
+        "urls": {
+            "advanced_search": "Mediensuche/Erweiterte-Suche",
+            "simple_search": "Mediensuche/Einfache-Suche"
         }
     },
     "geo": [
         49.749992,
         6.6371433
     ],
-    "information": "https://opac.trier.de/read_freshblue/info.html",
+    "information": "https://opac.trier.de",
     "state": "Rheinland-Pfalz",
-    "title": "Palais Walderdorff"
+    "title": "Stadtbibliothek Palais Walderdorff"
 }

--- a/opacclient/opacapp/src/main/assets/bibs/Wettingen.json
+++ b/opacclient/opacapp/src/main/assets/bibs/Wettingen.json
@@ -4,7 +4,7 @@
     "city": "Wettingen",
     "country": "Schweiz",
     "data": {
-        "baseurl": "http://62.2.168.69/webOPACClient.wettingen",
+        "baseurl": "http://opac.baden.ch/webOPACClient.wettingen",
         "startparams": "Login=opextern"
     },
     "geo": [


### PR DESCRIPTION
* Prolonging fixed for WinBiap 4.4 (tested in Memmingen)
* Getting cancelurl fixed for WinBiap 4.4 (tested using HTML sample, cancelling reservations itself not tested)
* New server for Baden and Wettingen
* Trier switched to OPEN
* Added libraries

For the first fix, I copied some code (essentially a RegEx) from the OPEN API implementation because both systems use Microsoft's ASP.NET framework and its "__doPostBack" Javascript mechanism. Should we instead transfer this code to a new function and place it in `BaseApi` or a new utility class?