### PR TITLE
Fix off-by-one for Nuremberg fix.

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Adis.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Adis.java
@@ -1238,7 +1238,7 @@ public class Adis extends BaseApi implements OpacApi {
                 if (date.contains("-")) {
                     // Nürnberg: "29.03.2016 - 26.04.2016"
                     // for beginning and end date in one field
-                    date = date.split("-", 1)[1].trim();
+                    date = date.split("-")[1].trim();
                 }
                 try {
                     item.setDeadline(fmt.parseLocalDate(date));


### PR DESCRIPTION
The limit in string.split() introduced by commit
8dfbc947d19c960b4200ec88f555ee187962a540
triggers an array out of bounds exception. Also since we want the second
result, the limit is wrong anyway. The date given has the form
(DD.MM.YYYY - DD.MM.YYYY) with the start and end date of the lending
period. For the account listing the second date is the relevant one.