### PR TITLE
Singleton for SQLite database, support detail links for old BiBer OPACs, add BiBer Test HTML

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/BiBer1992.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/BiBer1992.java
@@ -1004,7 +1004,7 @@ public class BiBer1992 extends BaseApi {
             LentItem item = new LentItem();
 
             Pattern itemIdPat = Pattern
-                    .compile("javascript:smAcc\\('[a-z]+','[a-z]+','([A-Za-z0-9]+)'\\)");
+                    .compile("javascript:(?:smAcc|smMedk)\\('[a-z]+','[a-z]+','([A-Za-z0-9]+)'\\)");
             // columns: all elements of one media
             Iterator<?> keys = copymap.keys();
             while (keys.hasNext()) {

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/BiBer1992AccountTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/BiBer1992AccountTest.java
@@ -28,7 +28,7 @@ public class BiBer1992AccountTest extends BaseAccountTest {
 
     private static final String[] FILES =
             new String[]{"gelsenkirchen.htm", "freising.html", "herford.htm", "erkrath_opac.html",
-                    "erkrath_opax.html"};
+                    "erkrath_opax.html", "nuertingen.html"};
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<String[]> files() {
@@ -88,6 +88,15 @@ public class BiBer1992AccountTest extends BaseAccountTest {
             accounttable.put("prolongurl", 1);
             accounttable.put("returndate", 3);
             accounttable.put("status", 9);
+            accounttable.put("title", 8);
+        } else if (file.equals("nuertingen.html")) {
+            accounttable.put("author", 8);
+            accounttable.put("barcode", 4);
+            accounttable.put("homebranch", -1);
+            accounttable.put("lendingbranch", -1);
+            accounttable.put("prolongurl", 4);
+            accounttable.put("returndate", 3);
+            accounttable.put("status", 6);
             accounttable.put("title", 8);
         }
         json.put("accounttable", accounttable);

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/BiBer1992AccountTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/BiBer1992AccountTest.java
@@ -27,7 +27,8 @@ public class BiBer1992AccountTest extends BaseAccountTest {
     }
 
     private static final String[] FILES =
-            new String[]{"gelsenkirchen.htm", "freising.html", "herford.htm"};
+            new String[]{"gelsenkirchen.htm", "freising.html", "herford.htm", "erkrath_opac.html",
+                    "erkrath_opax.html"};
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<String[]> files() {
@@ -70,6 +71,24 @@ public class BiBer1992AccountTest extends BaseAccountTest {
             accounttable.put("returndate", 3);
             accounttable.put("status", 9);
             accounttable.put("title", 8);
+        } else if (file.equals("erkrath_opac.html")) {
+            accounttable.put("author", 6);
+            accounttable.put("barcode", 3);
+            accounttable.put("homebranch", -1);
+            accounttable.put("lendingbranch", -1);
+            accounttable.put("prolongurl", 3);
+            accounttable.put("returndate", 2);
+            accounttable.put("status", 4);
+            accounttable.put("title", 6);
+        } else if (file.equals("erkrath_opax.html")) {
+            accounttable.put("author", 8);
+            accounttable.put("barcode", 4);
+            accounttable.put("homebranch", -1);
+            accounttable.put("lendingbranch", -1);
+            accounttable.put("prolongurl", 1);
+            accounttable.put("returndate", 3);
+            accounttable.put("status", 9);
+            accounttable.put("title", 8);
         }
         json.put("accounttable", accounttable);
         if (html == null) return; // we may not have all files for all libraries
@@ -77,6 +96,7 @@ public class BiBer1992AccountTest extends BaseAccountTest {
         assertTrue(media.size() > 0);
         for (LentItem item : media) {
             assertNotNull(item.getDeadline());
+            assertNotNull(item.getId());
         }
     }
 

--- a/opacclient/libopac/src/test/resources/biber1992/medialist/erkrath_opac.html
+++ b/opacclient/libopac/src/test/resources/biber1992/medialist/erkrath_opac.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html public "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!-- opac/de/user -->
+
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <link rel="stylesheet" HREF="OPAC.css.S" TYPE="text/css">
+    <title>OPAC der Stadtb&uuml;cherei Erkrath</title>
+    <script language="JavaScript" src="scripts-opac.js.S" type="text/javascript"></script>
+    <script language="JavaScript" type="text/javascript">
+window.setTimeout("javascript:noHist('s2')",60000);
+document.onkeydown = what;
+
+    </script>
+</head>
+<body onLoad="parent.frames[2].focus(); javascript:noHist('s1')">
+<br>
+
+
+<table class="tab1" border="0" cellpadding="1" cellspacing="0" width="100%">
+    <tr>
+        <td><h2>Medienkonto</h2></td>
+        <td align="right" valign="top"><h4>Stadtbibliothek Erkrath</h4></td>
+    </tr>
+</table>
+<div class="hr1"></div>
+<table class="tab1" border="0" width="100%">
+    <tr>
+        <td width="15%">XXXXXXXXX</td>
+        <td width="*">01 Test</td>
+        <td width="20%"></td>
+        <td width="20%">ausgeliehen: 2</td>
+    </tr>
+    <tr>
+        <td width="15%"></td>
+        <td width="*"> Ausweisg&uuml;ltigkeit: 03.11.2016</td>
+        <td width="20%"></td>
+        <td width="20%"></td>
+    </tr>
+    <tr>
+        <td>&nbsp;</td>
+        <td width="*"></td>
+        <td>&nbsp;</td>
+        <td width="20%"></td>
+    </tr>
+</table>
+
+<!-- Your output data goes in here -->
+
+<br>
+<font class="p61">Verl&auml;ngerungen bitte markieren und GO!-Taste klicken!</font>
+<form name="medkl" method="post" action="verl.C">
+    <input name="LANG" type="hidden" value="de">
+    <input name="FUNC" type="hidden" value="verl">
+    <input name="DUM1" type="hidden" value="">
+    <input name="DUM2" type="hidden" value="">
+    <input name="DUM3" type="hidden" value="">
+    <table border="1" width="100%">
+        <tr>
+            <th width="3%">&nbsp;</th>
+            <th width="3%">Nr</th>
+            <th width="10%">F&auml;llig</th>
+            <th width="12%">Mediennr</th>
+            <th width="3%"><p
+                    title="Verl&auml;ngerungen">&nbsp;V&nbsp;                                                                 </p>
+            </th>
+            <th width="3%"><p
+                    title="Mahnungen">&nbsp;M&nbsp;                                                                 </p>
+            </th>
+            <th width="*" align="left">Signatur / Kurztitel</th>
+            <th width="23%" colspan="2">Status</th>
+        </tr>
+        <tr>
+            <td width="3%"><input type="checkbox" name="101676742" value="YES">
+            <td width="3%" align="center">1</td>
+            <td width="10%" align="center">18.06.2016</td>
+            <td width="12%" align="center">101676742</td>
+            <td width="3%" align="center"> 1</td>
+            <td width="3%" align="center">&nbsp;</td>
+            <td width="*" align="left"><A
+                    href="javascript:smMedk('de','full','5201594')">CD Klassik B / Instrumente der </A>
+            </td>
+            <td width="10%" align="center">&nbsp;</td>
+            <td width="13%" align="center">&nbsp;</td>
+        </tr>
+        <tr>
+            <td width="3%"><input type="checkbox" name="101358480" value="YES">
+            <td width="3%" align="center">2</td>
+            <td width="10%" align="center">18.06.2016</td>
+            <td width="12%" align="center">101358480</td>
+            <td width="3%" align="center"> 1</td>
+            <td width="3%" align="center">&nbsp;</td>
+            <td width="*" align="left"><A
+                    href="javascript:smMedk('de','full','5166022')">CD Musik B / Hahn, Hilary: Silfra </A>
+            </td>
+            <td width="10%" align="center">&nbsp;</td>
+            <td width="13%" align="center">&nbsp;</td>
+        </tr>
+    </table>
+</form>
+
+
+<div class="hr1"></div>
+<br>
+<center>
+    <h2>Hier kommen Sie zu unserem neuen <a href="http://opac.erkrath.de/opax/de/index.html.S"
+                                            target="_top">Online-Katalog</a></h2>
+</center>
+<br>
+<table border="0">
+    <tr>
+        <td>
+            <h5>Webmaster : <a href="mailto:webmaster@erkrath.de">webmaster@erkrath.de</a><br>
+                / copyright 1992-2006 by BiBer GmbH<br>
+                &nbsp;&nbsp;All rights reserved</h5>
+        </td>
+        <td><img src="/opac/biber1.gif.S" border="0" alt=""></td>
+    <tr>
+</table>
+
+</body>
+</html>
+

--- a/opacclient/libopac/src/test/resources/biber1992/medialist/erkrath_opax.html
+++ b/opacclient/libopac/src/test/resources/biber1992/medialist/erkrath_opax.html
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN">
+
+<!-- opax/de/userl -->
+
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta http-equiv="pragma" content="no-cache">
+    <meta name="DC.subject" content="userl">
+    <title>OPAx Erkrath</title>
+    <script language="JavaScript" src="scripts-style.js.S" type="text/javascript"></script>
+    <script language="JavaScript" src="scripts-opax.js.S" type="text/javascript"></script>
+    <script language="JavaScript" src="de/_leftop.js.S" type="text/javascript"></script>
+    <script language="JavaScript" type="text/javascript">
+window.setTimeout("window.close()",120000);
+document.onkeydown = what;
+
+    </script>
+</head>
+<body>
+
+
+<div id="Lbox">
+    <script type="text/javascript"><!--
+swLeft('120');
+//-->
+    </script>
+    <div id="Kbox">
+        <br>
+        <font class="p66n">
+            &nbsp;Kontakt : <a href="mailto:stadtbuecherei@erkrath.de">stadtbuecherei@erkrath.de</a><br>
+            &nbsp;/ copyright 1992-2012<br>
+            &nbsp;by BiBer GmbH vers 12.10<br>
+            &nbsp;All rights reserved<br></font>
+
+        &nbsp;<img src="biber1.gif.S" border="0" title="BiBer GmbH">
+        &nbsp;<img src="opac1.gif.S" border="0" title="ausgezeichnet mit dem OPACaward 2009">
+    </div>
+
+</div>
+
+<div id="Tbox">
+    <script type="text/javascript"><!--
+swToop('200');
+//-->
+    </script>
+    <font class="p00b">
+        <div class="back01x">&nbsp;</div>
+    </font>
+</div>
+
+<div id="Mbox">
+    <table class="tab01" border="0">
+        <tr>
+            <td class="td01x11b">Medienkonto</td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+        </tr>
+    </table>
+    <h3></h3>
+    <table class="tab21" border="0" cellspacing="0" rules="none">
+        <tr>
+            <td class="td01x09n" width="15%">XXXXXXXXX</td>
+            <td class="td01x09n" width="*">01 Test</td>
+            <td class="td01x09n" width="20%"></td>
+            <td class="td01x09n" width="20%">ausgeliehen: 2</td>
+        </tr>
+        <tr>
+            <td class="td01x09n" width="15%">&nbsp;</td>
+            <td class="td01x09n" width="*"> Ausweisg&#252;ltigkeit: 03.11.2016</td>
+            <td class="td01x09n" width="20%"></td>
+            <td class="td01x09n" width="20%"></td>
+        </tr>
+        <tr>
+            <td class="td01x09n" width="*">
+                <div id="opACC" style="display:none;">011011000</div>
+                <br>
+                <div id="isACC" style="display:none;">1111100</div>
+            </td>
+            <td class="td01x09n" width="*"></td>
+            <td class="td01x09n" width="20%"></td>
+            <td class="td01x09n" width="20%"></td>
+        </tr>
+    </table>
+
+    <!-- Your output data goes in here -->
+
+    <form name="medkl" action="" method="post">
+        <input type="hidden" name="LANG" value="de">
+        <input type="hidden" name="FUNC" value="verl">
+        <input type="hidden" name="BENUTZER" value="XXXXXX">
+        <input type="hidden" name="PASSWORD" value="XXXXXXXX">
+        <br>
+        <table class="tab21" border="0" cellspacing="0" rules="none">
+            <tr>
+                <th width="10%">&nbsp;</th>
+                <th colspan="8" align="left"><font
+                        class="p06b">Verl&#228;ngerungen bitte markieren und<font> GO ! </font>klicken.</font>
+                </th>
+            </tr>
+            <tr>
+                <th class="th02x09b" width="10%">&nbsp;</th>
+                <th class="th02x09b" width="*"><img src="icon/pfeild_red.gif.S"
+                                                    title="Bitte markieren Sie in dieser Spalte!">
+                </th>
+                <th class="th02x09b" width="*">Nr</th>
+                <th class="th02x09b" width="*">F&#228;llig</th>
+                <th class="th02x09b" width="*">Mediennr</th>
+                <th class="th02x09b" width="*">
+                    <div onmouseover="tooTip(this, {txt: 'Medienstandort', styNam:'toTip1'})"><font
+                            class="p06b infox">&nbsp;A&nbsp;</font></div>
+                </th>
+                <th class="th02x09b" width="*">
+                    <div onmouseover="tooTip(this, {txt: 'Verl&#228;ngerungen', styNam:'toTip1'})">
+                        <font class="p06b infox">&nbsp;V&nbsp;</font></div>
+                </th>
+                <th class="th02x09b" width="*">
+                    <div onmouseover="tooTip(this, {txt: 'Mahnungen', styNam:'toTip1'})"><font
+                            class="p06b infox">&nbsp;M&nbsp;</font></div>
+                </th>
+                <th class="th02x09b" width="*" align="left">Vormerkung: Signatur / Kurztitel</th>
+                <th class="th02x09b" width="*" colspan="2">Status</th>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="icon/6.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="101676742"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">18.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">101676742</td>
+                <td class="td01b1 td01x09n" width="*" align="center"><font class="p06b"
+                                                                           title="B&#252;rgerhaus">B</font>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','5201594')"
+                        title="Zur Volltitelinformation">CD Klassik B / Instrumente der </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center"><font
+                        class="p44b">verl&#228;ngert</font></td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="icon/6.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="101358480"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">2</td>
+                <td class="td01b1 td01x09n" width="*" align="center">18.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">101358480</td>
+                <td class="td01b1 td01x09n" width="*" align="center"><font class="p06b"
+                                                                           title="B&#252;rgerhaus">B</font>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','5166022')"
+                        title="Zur Volltitelinformation">CD Musik B / Hahn, Hilary: Silfra </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center"><font
+                        class="p44b">verl&#228;ngert</font></td>
+            </tr>
+        </table>
+    </form>
+
+
+    <table class="tab09" border="0">
+        <tr>
+            <td>&nbsp;</td>
+        </tr>
+    </table>
+    <br>
+    <br><br>
+
+</div>
+
+</body>
+</html>

--- a/opacclient/libopac/src/test/resources/biber1992/medialist/nuertingen.html
+++ b/opacclient/libopac/src/test/resources/biber1992/medialist/nuertingen.html
@@ -1,0 +1,800 @@
+<!DOCTYPE html public "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!-- opax/de/userl -->
+
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta http-equiv="pragma" content="no-cache">
+    <meta name="DC.subject" content="userl">
+    <title>OPAx Stadtb&#252;cherei N&#252;rtingen</title>
+    <script language="JavaScript" src="scripts-style.js.S" type="text/javascript"></script>
+    <script language="JavaScript" src="scripts-opax.js.S" type="text/javascript"></script>
+    <script language="JavaScript" src="de/_leftop.js.S" type="text/javascript"></script>
+    <script language="JavaScript" type="text/javascript">
+window.setTimeout("javascript:noHist('s2')",90000);
+document.onkeydown = what;
+
+    </script>
+</head>
+<body onLoad="javascript:noHist('s1')">
+
+
+<div id="Lbox">
+    <script type="text/javascript"><!--
+swLeft('99');
+document.getElementById("LeftBox1").style.visibility = "visible";
+//-->
+    </script>
+    <br><br>
+    <font class="p66n">
+        &nbsp;Fragen, Anregungen, W&#252;nsche: <a href="mailto:stadtbuecherei@nuertingen.de">
+        <font color="#FFDEAD">&nbsp;stadtbuecherei@nuertingen.de</font></a><br>
+        &nbsp;/ copyright 1992-2012<br>
+        &nbsp;by BiBer GmbH vers 11.02<br>
+        &nbsp;All rights reserved<br></font>
+
+
+</div>
+
+<div id="Tbox">
+    <script type="text/javascript"><!--
+swToop('0');
+//-->
+    </script>
+    <div align="left"><font
+            class="p00b"><br>&nbsp;&nbsp;&nbsp;Stadtb&#252;cherei N&#252;rtingen</font></div>
+</div>
+
+<div id="Mbox">
+    <table class="tab01" border="0">
+        <tr>
+            <td class="td01x12b"></td>
+            <td>&nbsp;</td>
+            <td>&nbsp;</td>
+        </tr>
+    </table>
+    <h3></h3>
+    <table class="tab21" border="0" cellspacing="0" rules="none">
+        <tr>
+            <td class="td01x09n" width="15%">0000XXXXXXX</td>
+            <td class="td01x09n" width="*">Max Mustermann</td>
+            <td class="td01x09n" width="20%"></td>
+            <td class="td01x09n" width="20%">ausgeliehen: 29</td>
+        </tr>
+        <tr>
+            <td class="td01x09n" width="15%"></td>
+            <td class="td01x09n" width="*"> Ausweisg&#252;ltigkeit: 31.01.2017</td>
+            <td class="td01x09n" width="20%"></td>
+            <td class="td01x09n" width="20%"></td>
+        </tr>
+        <tr>
+            <td>&nbsp;</td>
+            <td class="td01x09n" width="*"></td>
+            <td>&nbsp;</td>
+            <td class="td01x09n" width="20%"></td>
+        </tr>
+    </table>
+
+    <!-- Your output data goes in here -->
+
+    <form name="medkl" action="" method="post">
+        <input type="hidden" name="LANG" value="de">
+        <input type="hidden" name="FUNC" value="verl">
+        <input type="hidden" name="BENUTZER" value="XXXXXXX">
+        <input type="hidden" name="PASSWORD" value="XXXXXX">
+        <table class="tab21" border="0" cellspacing="0" rules="none">
+            <tr>
+                <th width="10%">&nbsp;</th>
+                <th colspan="8" align="left"><font
+                        class="p06b">Verl&#228;ngerungen bitte markieren und<font> GO ! </font>klicken.</font>
+                </th>
+            </tr>
+            <tr>
+                <th class="th02x09b" width="10%">&nbsp;</th>
+                <th class="th02x09b" width="*"><img src="image/pfeild_red.gif.S"
+                                                    title="Bitte markieren Sie in dieser Spalte!">
+                </th>
+                <th class="th02x09b" width="*">Nr</th>
+                <th class="th02x09b" width="*">F&#228;llig</th>
+                <th class="th02x09b" width="*">Mediennr</th>
+                <th class="th02x09b" width="*"><font class="p06b"
+                                                     title="Ausgabeort">&nbsp;A&nbsp;</font></th>
+                <th class="th02x09b" width="*"><font class="p06b"
+                                                     title="Verl&#228;ngerungen">&nbsp;V&nbsp;</font>
+                </th>
+                <th class="th02x09b" width="*"><font class="p06b"
+                                                     title="Mahnungen">&nbsp;M&nbsp;</font></th>
+                <th class="th02x09b" width="*" align="left">Signatur / Kurztitel</th>
+                <th class="th02x09b" width="*" colspan="2">Status</th>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/20.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102627095"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">11.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102627095</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','467620280')"
+                        title="Zur Volltitelinformation">Sachh&#246;rbuch Psy 840,5 / Berndt, </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102641516"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">2</td>
+                <td class="td01b1 td01x09n" width="*" align="center">11.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102641516</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','463906357')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 290 / Fischer, </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102529942"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">3</td>
+                <td class="td01b1 td01x09n" width="*" align="center">22.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102529942</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','463543700')"
+                        title="Zur Volltitelinformation">Beruf BWL 120 / Gulder, Angelika: </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="101531836"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">4</td>
+                <td class="td01b1 td01x09n" width="*" align="center">22.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">101531836</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','1011475')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 505 / Low Carb - das </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102619957"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">5</td>
+                <td class="td01b1 td01x09n" width="*" align="center">22.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102619957</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','464260175')"
+                        title="Zur Volltitelinformation">HW 488 / Das vegane Grillbuch </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102842072"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">6</td>
+                <td class="td01b1 td01x09n" width="*" align="center">22.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102842072</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','464467318')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n Med 553 Saeu / Detox - </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102678068"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">7</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102678068</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','464303962')"
+                        title="Zur Volltitelinformation">Psy 432 / Mary, Michael: Der </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102880043"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">8</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102880043</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','464281038')"
+                        title="Zur Volltitelinformation">HW 488 / Vegan kochen </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102676671"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">9</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102676671</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','381137')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n Med 210 / Strunz, </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102623761"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">10</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102623761</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','463734251')"
+                        title="Zur Volltitelinformation">HW 488 / Gabel statt Skalpell </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/2.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102488849"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">11</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102488849</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','463134306')"
+                        title="Zur Volltitelinformation">Krimi Hill / Hill, Antonio: Der Sommer </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="101764328"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">12</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">101764328</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','204606')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 505 / Strunz, Ulrich: </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102509630"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">13</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102509630</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','463550779')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 505 / Schocke, Sarah: </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102300194"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">14</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102300194</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','462825050')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 505 / Thiel, Susanne: </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102651971"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">15</td>
+                <td class="td01b1 td01x09n" width="*" align="center">25.06.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102651971</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 2</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','463896010')"
+                        title="Zur Volltitelinformation">HW 488 / Start vegan! </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102482425"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">16</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102482425</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','282854')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 505 / Cavelius, Anna: </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102426724"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">17</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102426724</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','463201883')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 505 / Botta, </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="101690841"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">18</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">101690841</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','10056406')"
+                        title="Zur Volltitelinformation">HW 450 / Spargel </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102443288"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">19</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102443288</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','286041')"
+                        title="Zur Volltitelinformation">Bast 960 / Holzpfosten dekorativ </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102880593"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">20</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102880593</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','384955')"
+                        title="Zur Volltitelinformation">Med 553 Saeu / Edgson, Vicki: </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102449587"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">21</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102449587</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','350726')"
+                        title="Zur Volltitelinformation">Ma 935 / Magnello, Eileen: Statistik </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102669163"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">22</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102669163</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','464121362')"
+                        title="Zur Volltitelinformation">Spo 74 / Vegan, schlank & fit </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102848128"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">23</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102848128</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','464431552')"
+                        title="Zur Volltitelinformation">Bast 997,1 / Wohndesign f&#252;r </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102676051"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">24</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102676051</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','464095045')"
+                        title="Zur Volltitelinformation">Spo 78 / Lauren, Mark: Fit ohne Ger&#228;te </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102158496"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">25</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102158496</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','462498860')"
+                        title="Zur Volltitelinformation">Med 553 Saeu / Wacker, Sabine: </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102304671"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">26</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102304671</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','467499372')"
+                        title="Zur Volltitelinformation">Spra 330 / Schwedisch in 30 Tagen </A></td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102485905"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">27</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102485905</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','463185771')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 505 / Elmadfa, </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102334731"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">28</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102334731</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 1</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','462825095')"
+                        title="Zur Volltitelinformation">Fit und sch&#246;n HW 505 / Gassert, </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+            <tr valign="middle">
+                <td class="td01b1 td03q1" width="5%" align="center"><img src="image/1.gif.S"
+                                                                         border="0" valign="bottom"
+                                                                         title="Medientyp"></td>
+                <td class="td01b1 td03q1" width="3%" align="center"><input type="checkbox"
+                                                                           name="102314560"
+                                                                           value="YES"></td>
+                <td class="td01b1 td01x09n" width="*" align="center">29</td>
+                <td class="td01b1 td01x09n" width="*" align="center">02.07.2016</td>
+                <td class="td01b1 td01x09n" width="*" align="center">102314560</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;<font class="p06b"
+                                                                                 title="Hauptstelle">HS</font>&nbsp;
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center"> 0</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="left"><A
+                        href="javascript:smAcc('de','full','280082')"
+                        title="Zur Volltitelinformation">Ma 935 / Kr&#228;mer, Walter: Statistik </A>
+                </td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+                <td class="td01b1 td01x09n" width="*" align="center">&nbsp;</td>
+            </tr>
+        </table>
+    </form>
+
+
+    <table class="tab09" border="0">
+        <tr>
+            <td>&nbsp;</td>
+        </tr>
+    </table>
+    <br>
+    <div>
+        <a href="http://www.onleihe.de/247online-bibliothek//" target=_blank><img
+                src="/opax/image/onleihe300.jpg.S" border="0" alt"Onleihe 24*7"></a></td>
+
+    </div>
+</div>
+
+</div>
+
+<!--
+<table width="81%">
+ <tr>
+  <th>
+   <table width="*" style="border-collapse:collapse" align="left">
+    <tr><td class="td9" colspan="2"><b>Stadtb&#252;cherei</b></td><td class="td9" rowspan="8" width="11%">&nbsp;</td></tr>
+    <tr><td class="td9">Montag</td><td class="td9">Vormittag / Nachmittag</td></tr>
+    <tr><td class="td9">Dienstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Mittwoch</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Donnerstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Freitag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Samstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9"><font color="red"> Telefon:</font></td><td class="td9">01234 / 6789</td></tr>
+   </table>
+
+   <table width="*" style="border-collapse:collapse" align="left">
+    <tr><td class="td9" colspan="2"><b>Zweigstelle Nord</b></td><td class="td9" rowspan="8" width="11%">&nbsp;</td></tr>
+    <tr><td class="td9">Montag</td><td class="td9">Vormittag / Nachmittag</td></tr>
+    <tr><td class="td9">Dienstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Mittwoch</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Donnerstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Freitag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Samstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Telefon:</td><td class="td9">01234 / 6789</td></tr>
+   </table>
+
+   <table width="*" style="border-collapse:collapse" align="left">
+    <tr><td class="td9" colspan="2"><b>Zweigstelle S&#252;d</b></td></tr>
+    <tr><td class="td9">Montag</td><td class="td9">Vormittag / Nachmittag</td></tr>
+    <tr><td class="td9">Dienstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Mittwoch</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Donnerstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Freitag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Samstag</td><td class="td9">Vorm. / Nachm.</td></tr>
+    <tr><td class="td9">Telefon:</td><td class="td9">01234 / 6789</td></tr>
+   </table>
+
+  </th>
+ </tr>
+</table>
+
+-->
+
+</div>
+
+</body>
+</html>

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/OpacClient.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/OpacClient.java
@@ -18,14 +18,6 @@
  */
 package de.geeksfactory.opacclient;
 
-import com.commonsware.cwac.wakeful.WakefulIntentService;
-
-import org.acra.ACRA;
-import org.acra.ACRAConfiguration;
-import org.acra.annotation.ReportsCrashes;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
@@ -40,6 +32,14 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.ActivityCompat;
 import android.util.Log;
+
+import com.commonsware.cwac.wakeful.WakefulIntentService;
+
+import org.acra.ACRA;
+import org.acra.ACRAConfiguration;
+import org.acra.annotation.ReportsCrashes;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -227,9 +227,7 @@ public class OpacClient extends Application {
             }
         }
         AccountDataSource data = new AccountDataSource(this);
-        data.open();
         account = data.getAccount(sp.getLong(PREF_SELECTED_ACCOUNT, 0));
-        data.close();
         return account;
     }
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountEditActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountEditActivity.java
@@ -84,7 +84,6 @@ public class AccountEditActivity extends AppCompatActivity {
         etPassword = (EditText) findViewById(R.id.etPassword);
 
         AccountDataSource data = new AccountDataSource(this);
-        data.open();
         account = data.getAccount(getIntent()
                 .getLongExtra(EXTRA_ACCOUNT_ID, -1));
 
@@ -92,8 +91,6 @@ public class AccountEditActivity extends AppCompatActivity {
             finish();
             return;
         }
-
-        data.close();
 
         if (account.getLabel().equals(getString(R.string.default_account_name))) {
             etLabel.setText("");
@@ -169,7 +166,6 @@ public class AccountEditActivity extends AppCompatActivity {
 
     private void delete() {
         AccountDataSource data = new AccountDataSource(this);
-        data.open();
         data.remove(account);
 
         // Check whether he deleted account was selected
@@ -184,7 +180,6 @@ public class AccountEditActivity extends AppCompatActivity {
                         .get(0).getId());
             }
         }
-        data.close();
         new ReminderHelper((OpacClient) getApplication()).generateAlarms();
     }
 
@@ -257,9 +252,7 @@ public class AccountEditActivity extends AppCompatActivity {
 
     private void save() {
         AccountDataSource data = new AccountDataSource(AccountEditActivity.this);
-        data.open();
         data.update(account);
-        data.close();
         if (((OpacClient) getApplication()).getAccount().getId() == account
                 .getId()) {
             ((OpacClient) getApplication()).resetCache();

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountFragment.java
@@ -233,10 +233,8 @@ public class AccountFragment extends Fragment implements
         Context ctx = getActivity() != null ? getActivity() : OpacClient
                 .getEmergencyContext();
         AccountDataSource adatasource = new AccountDataSource(ctx);
-        adatasource.open();
         AccountData data = adatasource.getCachedAccountData(account);
         LocalDateTime dt = new LocalDateTime(adatasource.getCachedAccountDataTime(account));
-        adatasource.close();
 
         if (data == null) return;
 
@@ -394,7 +392,6 @@ public class AccountFragment extends Fragment implements
             Context ctx = getActivity() != null ? getActivity() : OpacClient
                     .getEmergencyContext();
             AccountDataSource adatasource = new AccountDataSource(ctx);
-            adatasource.open();
             refreshtime = adatasource.getCachedAccountDataTime(account);
             if (refreshtime > 0) {
                 displaydata(adatasource.getCachedAccountData(account), true);
@@ -404,7 +401,6 @@ public class AccountFragment extends Fragment implements
             } else {
                 refresh();
             }
-            adatasource.close();
         }
     }
 
@@ -654,9 +650,7 @@ public class AccountFragment extends Fragment implements
 
     public void invalidateData() {
         AccountDataSource adatasource = new AccountDataSource(getActivity());
-        adatasource.open();
         adatasource.invalidateCachedAccountData(account);
-        adatasource.close();
         svAccount.setVisibility(View.GONE);
         accountSelected(account);
     }
@@ -670,9 +664,7 @@ public class AccountFragment extends Fragment implements
         }
         if (e instanceof OpacErrorException) {
             AccountDataSource adatasource = new AccountDataSource(getActivity());
-            adatasource.open();
             adatasource.invalidateCachedAccountData(account);
-            adatasource.close();
             dialog_wrong_credentials(e.getMessage());
             return;
         }
@@ -1625,11 +1617,9 @@ public class AccountFragment extends Fragment implements
                     adatasource = new AccountDataSource(getActivity());
                 }
 
-                adatasource.open();
                 account.setPasswordKnownValid(true);
                 adatasource.update(account);
                 adatasource.storeCachedAccountData(adatasource.getAccount(data.getAccount()), data);
-                adatasource.close();
 
                 new ReminderHelper(app).generateAlarms();
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountListActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountListActivity.java
@@ -97,9 +97,7 @@ public class AccountListActivity extends AppCompatActivity {
     public void refreshLv() {
         ListView lvAccounts = (ListView) findViewById(R.id.lvAccounts);
         AccountDataSource data = new AccountDataSource(this);
-        data.open();
         accounts = data.getAllAccounts();
-        data.close();
         AccountListAdapter adapter = new AccountListAdapter(this, accounts);
         lvAccounts.setAdapter(adapter);
     }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/DrawerAccountsAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/DrawerAccountsAdapter.java
@@ -50,14 +50,12 @@ public class DrawerAccountsAdapter extends RecyclerView.Adapter<RecyclerView.Vie
         int tolerance = Integer.parseInt(sp.getString("notification_warning", "3"));
 
         AccountDataSource adata = new AccountDataSource(context);
-        adata.open();
         for (Account account : accounts) {
             expiring.put(account, adata.getExpiring(account, tolerance));
             if (account.getId() != currentAccount.getId()) {
                 accountsWithoutCurrent.add(account);
             }
         }
-        adata.close();
     }
 
     @Override

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
@@ -616,13 +616,11 @@ public class LibraryListActivity extends AppCompatActivity
                 case LEVEL_LIBRARY:
                     Library lib = (Library) getListAdapter().getItem(position);
                     AccountDataSource data = new AccountDataSource(getActivity());
-                    data.open();
                     Account acc = new Account();
                     acc.setLibrary(lib.getIdent());
                     acc.setLabel(getActivity().getString(
                             R.string.default_account_name));
                     long insertedid = data.addAccount(acc);
-                    data.close();
 
                     ((OpacClient) getActivity().getApplication())
                             .setAccount(insertedid);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainActivity.java
@@ -113,9 +113,7 @@ public class MainActivity extends OpacActivity
                     || getIntent().getAction().equals("de.geeksfactory.opacclient.ACCOUNT")) {
                 String lib = getIntent().getStringExtra("library");
                 AccountDataSource adata = new AccountDataSource(this);
-                adata.open();
                 List<Account> accounts = adata.getAllAccounts(lib);
-                adata.close();
 
                 if (accounts.size() == 0) {
                     // Check if library exists (an IOException should be thrown otherwise, correct?)
@@ -129,9 +127,7 @@ public class MainActivity extends OpacActivity
                     account.setLabel(getString(R.string.default_account_name));
                     account.setName("");
                     account.setPassword("");
-                    adata.open();
                     long id = adata.addAccount(account);
-                    adata.close();
                     selectaccount(id);
                 } else if (accounts.size() == 1) {
                     selectaccount(accounts.get(0).getId());
@@ -153,7 +149,6 @@ public class MainActivity extends OpacActivity
                 selectItem(getIntent().getStringExtra(EXTRA_FRAGMENT));
             } else if (getIntent().hasExtra(ReminderBroadcastReceiver.EXTRA_ALARM_ID)) {
                 AccountDataSource adata = new AccountDataSource(this);
-                adata.open();
                 Alarm alarm = adata.getAlarm(
                         getIntent().getLongExtra(ReminderBroadcastReceiver.EXTRA_ALARM_ID, -1));
                 List<LentItem> items = adata.getLentItems(alarm.media);
@@ -178,7 +173,6 @@ public class MainActivity extends OpacActivity
                         selectItem("account");
                     }
                 }
-                adata.close();
             } else if (itemToSelect != null) {
                 selectItem(itemToSelect);
             } else if (sp.contains("startup_fragment")) {
@@ -257,9 +251,7 @@ public class MainActivity extends OpacActivity
 
             if (app.getLibrary() == null || !app.getLibrary().getIdent().equals(bib)) {
                 AccountDataSource adata = new AccountDataSource(this);
-                adata.open();
                 List<Account> accounts = adata.getAllAccounts(bib);
-                adata.close();
                 if (accounts.size() > 0) {
                     app.setAccount(accounts.get(0).getId());
                 } else {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainPreferenceFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainPreferenceFragment.java
@@ -128,9 +128,7 @@ public class MainPreferenceFragment extends PreferenceFragmentCompat {
                 @Override
                 public boolean onPreferenceClick(Preference arg0) {
                     AccountDataSource adata = new AccountDataSource(context);
-                    adata.open();
                     adata.invalidateCachedData();
-                    adata.close();
                     new ReminderHelper((OpacClient) context.getApplication()).updateAlarms(-1);
 
                     SearchFieldDataSource sfdata = new JsonSearchFieldDataSource(context);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/OpacActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/OpacActivity.java
@@ -160,9 +160,7 @@ public abstract class OpacActivity extends AppCompatActivity
 
     protected void setupAccountSwitcher() {
         if (drawer == null || app.getAccount() == null) return;
-        aData.open();
         accounts = aData.getAllAccounts();
-        aData.close();
 
         Account selectedAccount = app.getAccount();
 
@@ -528,14 +526,12 @@ public abstract class OpacActivity extends AppCompatActivity
                     stream.close();
                 } catch (IOException e) {
                     AccountDataSource data = new AccountDataSource(this);
-                    data.open();
                     data.remove(app.getAccount());
                     List<Account> available_accounts = data.getAllAccounts();
                     if (available_accounts.size() > 0) {
                         ((OpacClient) getApplication())
                                 .setAccount(available_accounts.get(0).getId());
                     }
-                    data.close();
                     new ReminderHelper(app).generateAlarms();
                     if (app.getLibrary() != null) {
                         return;
@@ -561,10 +557,7 @@ public abstract class OpacActivity extends AppCompatActivity
         if (account == null) return;
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
         int tolerance = Integer.parseInt(sp.getString("notification_warning", "3"));
-
-        aData.open();
         int expiring = aData.getExpiring(account, tolerance);
-        aData.close();
 
         accountTitle.setText(Utils.getAccountTitle(account, this));
         accountSubtitle.setText(Utils.getAccountSubtitle(account, this));
@@ -586,9 +579,7 @@ public abstract class OpacActivity extends AppCompatActivity
 
         ListView lv = (ListView) view.findViewById(R.id.lvBibs);
         AccountDataSource data = new AccountDataSource(this);
-        data.open();
         final List<Account> accounts = data.getAllAccounts();
-        data.close();
         AccountListAdapter adapter = new AccountListAdapter(this, accounts);
         lv.setAdapter(adapter);
         lv.setOnItemClickListener(new OnItemClickListener() {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultDetailFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultDetailFragment.java
@@ -804,10 +804,8 @@ public class SearchResultDetailFragment extends Fragment
         }
 
         AccountDataSource data = new AccountDataSource(getActivity());
-        data.open();
         final List<Account> accounts = data.getAccountsWithPassword(app
                 .getLibrary().getIdent());
-        data.close();
         if (accounts.size() == 0) {
             dialog_no_credentials();
         } else if (accounts.size() > 1
@@ -919,9 +917,7 @@ public class SearchResultDetailFragment extends Fragment
             @Override
             public void onSuccess(MultiStepResult result) {
                 AccountDataSource adata = new AccountDataSource(getActivity());
-                adata.open();
                 adata.invalidateCachedAccountData(app.getAccount());
-                adata.close();
                 if (result.getMessage() != null) {
                     AlertDialog.Builder builder = new AlertDialog.Builder(
                             getActivity());
@@ -982,10 +978,8 @@ public class SearchResultDetailFragment extends Fragment
 
     protected void bookingStart() {
         AccountDataSource data = new AccountDataSource(getActivity());
-        data.open();
         final List<Account> accounts = data.getAccountsWithPassword(app
                 .getLibrary().getIdent());
-        data.close();
         if (accounts.size() == 0) {
             dialog_no_credentials();
         } else if (accounts.size() > 1) {
@@ -1035,9 +1029,7 @@ public class SearchResultDetailFragment extends Fragment
                     return;
                 }
                 AccountDataSource adata = new AccountDataSource(getActivity());
-                adata.open();
                 adata.invalidateCachedAccountData(app.getAccount());
-                adata.close();
                 Intent intent = new Intent(getActivity(), app.getMainActivity());
                 intent.putExtra(MainActivity.EXTRA_FRAGMENT, "account");
                 getActivity().startActivity(intent);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultListFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultListFragment.java
@@ -160,9 +160,7 @@ public class SearchResultListFragment extends CustomListFragment {
 
     private void performGoogleSearch(final String query) {
         AccountDataSource data = new AccountDataSource(getActivity());
-        data.open();
         final List<Account> accounts = data.getAllAccounts();
-        data.close();
 
         if (accounts.size() == 0) {
             Toast.makeText(getActivity(), R.string.welcome_select,

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SnoozeDatePickerActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SnoozeDatePickerActivity.java
@@ -1,7 +1,5 @@
 package de.geeksfactory.opacclient.frontend;
 
-import org.joda.time.DateTime;
-
 import android.app.Activity;
 import android.app.DatePickerDialog;
 import android.app.NotificationManager;
@@ -12,6 +10,8 @@ import android.os.Bundle;
 import android.text.format.DateFormat;
 import android.widget.DatePicker;
 import android.widget.TimePicker;
+
+import org.joda.time.DateTime;
 
 import de.geeksfactory.opacclient.OpacClient;
 import de.geeksfactory.opacclient.R;
@@ -52,12 +52,10 @@ public class SnoozeDatePickerActivity extends Activity
 
         long alarmId = getIntent().getLongExtra(ReminderBroadcastReceiver.EXTRA_ALARM_ID, -1);
         AccountDataSource adata = new AccountDataSource(this);
-        adata.open();
         Alarm alarm = adata.getAlarm(alarmId);
         alarm.notified = false;
         alarm.notificationTime = dt;
         adata.updateAlarm(alarm);
-        adata.close();
 
         // dismiss notification
         NotificationManager manager = (NotificationManager) getSystemService(

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/ReminderBroadcastReceiver.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/ReminderBroadcastReceiver.java
@@ -51,11 +51,9 @@ public class ReminderBroadcastReceiver extends BroadcastReceiver {
         this.prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
         adata = new AccountDataSource(context);
-        adata.open();
         alarm = adata.getAlarm(intent.getLongExtra(EXTRA_ALARM_ID, -1));
 
         if (alarm == null) {
-            adata.close();
             return;
         }
 
@@ -76,7 +74,6 @@ public class ReminderBroadcastReceiver extends BroadcastReceiver {
                 notificationDontRemindAgain();
                 break;
         }
-        adata.close();
         // reschedule alarms
         new ReminderHelper((OpacClient) context.getApplicationContext()).scheduleAlarms();
     }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/ReminderHelper.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/ReminderHelper.java
@@ -61,7 +61,6 @@ public class ReminderHelper {
         }
 
         AccountDataSource data = new AccountDataSource(app);
-        data.open();
         List<LentItem> items = data.getAllLentItems();
 
         // Sort lent items by deadline
@@ -113,9 +112,6 @@ public class ReminderHelper {
                         deadline.minusDays(warning).toDateTimeAtStartOfDay());
             }
         }
-
-        data.close();
-
         scheduleAlarms(true);
     }
 
@@ -143,9 +139,7 @@ public class ReminderHelper {
 
     private void clearAlarms() {
         AccountDataSource data = new AccountDataSource(app);
-        data.open();
         data.clearAlarms();
-        data.close();
     }
 
     private void cancelNotification(Alarm alarm) {
@@ -173,9 +167,7 @@ public class ReminderHelper {
         AccountDataSource data = new AccountDataSource(app);
         AlarmManager alarmManager = (AlarmManager) app.getSystemService(Context.ALARM_SERVICE);
 
-        data.open();
         List<Alarm> alarms = data.getAllAlarms();
-        data.close();
 
         for (Alarm alarm : alarms) {
             if (!alarm.notified) {
@@ -214,7 +206,6 @@ public class ReminderHelper {
      */
     public void resetNotified() {
         AccountDataSource data = new AccountDataSource(app);
-        data.open();
         List<Alarm> alarms = data.getAllAlarms();
 
         for (Alarm alarm : alarms) {
@@ -223,7 +214,5 @@ public class ReminderHelper {
                 data.updateAlarm(alarm);
             }
         }
-
-        data.close();
     }
 }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/SyncAccountService.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/SyncAccountService.java
@@ -95,9 +95,7 @@ public class SyncAccountService extends WakefulIntentService {
     private void syncAccounts() {
         OpacClient app = (OpacClient) getApplication();
         AccountDataSource data = new AccountDataSource(this);
-        data.open();
         List<Account> accounts = data.getAccountsWithPassword();
-        data.close();
 
         try {
             for (Account account : accounts) {
@@ -115,20 +113,14 @@ public class SyncAccountService extends WakefulIntentService {
                         continue;
                     }
                 } catch (JSONException | IOException | OpacApi.OpacErrorException e) {
-                    data.close();
                     e.printStackTrace();
                     failed = true;
                     continue;
                 }
 
-                data.open();
-                try {
-                    account.setPasswordKnownValid(true);
-                    data.update(account);
-                    data.storeCachedAccountData(account, res);
-                } finally {
-                    data.close();
-                }
+                account.setPasswordKnownValid(true);
+                data.update(account);
+                data.storeCachedAccountData(account, res);
             }
         } finally {
             new ReminderHelper(app).generateAlarms();

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDataSource.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDataSource.java
@@ -18,14 +18,13 @@
  */
 package de.geeksfactory.opacclient.storage;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
-import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,19 +39,14 @@ import de.geeksfactory.opacclient.reminder.Alarm;
 public class AccountDataSource {
     // Database fields
     private SQLiteDatabase database;
-    private AccountDatabase dbHelper;
     private String[] allColumns = AccountDatabase.COLUMNS;
 
     public AccountDataSource(Context context) {
-        dbHelper = new AccountDatabase(context);
-    }
-
-    public void open() throws SQLException {
+        AccountDatabase dbHelper = AccountDatabase.getInstance(context);
         database = dbHelper.getWritableDatabase();
-    }
-
-    public void close() {
-        dbHelper.close();
+        // we do not need to close the database, as only one instance is created
+        // see e.g. http://stackoverflow
+        // .com/questions/4547461/closing-the-database-in-a-contentprovider/12715032#12715032
     }
 
     public long addAccount(Account acc) {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDatabase.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/AccountDatabase.java
@@ -28,6 +28,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 
 public class AccountDatabase extends SQLiteOpenHelper {
 
+    private static AccountDatabase instance;
     public static final String[] COLUMNS = {"id", "bib", "label", "name",
             "password", "cached", "pendingFees", "validUntil", "warning", "passwordValid"};
     public static final String[] COLUMNS_ALARMS = {"id", "deadline", "media", "alarm",
@@ -46,8 +47,13 @@ public class AccountDatabase extends SQLiteOpenHelper {
     private static final String DATABASE_NAME = "accounts.db";
     private static final int DATABASE_VERSION = 26; // REPLACE ONUPGRADE IF YOU
 
-    public AccountDatabase(Context context) {
+    private AccountDatabase(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    public static synchronized AccountDatabase getInstance(Context context) {
+        if (instance == null) instance = new AccountDatabase(context);
+        return instance;
     }
 
     @Override


### PR DESCRIPTION
To avoid `DatabaseLockedException`, I changed `AccountDatabase` so that there is only one instance of it created. According to multiple sources, e.g.

http://stackoverflow.com/questions/4547461/closing-the-database-in-a-contentprovider/12715032#12715032 and
http://touchlabblog.tumblr.com/post/24474750219/single-sqlite-connection

we can then omit calling `close()` on the database instead of having to count the number of concurrent accesses to make sure we don't close the DB while a thread is still using it.