### PR TITLE
Bibliotheca fix, Test coverage, Leak Canary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
         - extra-android-m2repository
 script:
     - cd opacclient
-    - ./gradlew check lint test
+    - ./gradlew check lint test coveralls
 cache:
     directories:
         - $HOME/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
         - extra-android-m2repository
 script:
     - cd opacclient
-    - ./gradlew check lint test coveralls
+    - ./gradlew check lint test jacocoTestReport coveralls
 cache:
     directories:
         - $HOME/.gradle

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Web Opac App [![Build Status](https://travis-ci.org/opacapp/opacclient.svg?branch=master)](https://travis-ci.org/opacapp/opacclient)[![Coverage Status](https://coveralls.io/repos/github/opacapp/opacclient/badge.svg?branch=master)](https://coveralls.io/github/opacapp/opacclient?branch=master)
+Web Opac App [![Build Status](https://travis-ci.org/opacapp/opacclient.svg?branch=master)](https://travis-ci.org/opacapp/opacclient)
 ============
 Android client for public libraries. See [opacapp.net](http://opacapp.net) for details.
 
@@ -32,8 +32,10 @@ projects because it does not depend on Android APIs. More information about the 
 Contributing
 ------------
 We'd like to invite you to contribute to our project, e.g. by improving the user interface or adding support
-for new libraries. Checking out the project with Android Studio should be fairly straightforward, but we
-also got a little bit of information in the [project wiki](https://github.com/opacapp/opacclient/wiki).
+for new libraries. Additionally, you could help to extend our test suite to increase this number: [![Coverage Status](https://coveralls.io/repos/github/opacapp/opacclient/badge.svg?branch=master)](https://coveralls.io/github/opacapp/opacclient?branch=master) :wink:.
+
+Checking out the project with Android Studio should be fairly straightforward, but we
+also have a little bit of information in the [project wiki](https://github.com/opacapp/opacclient/wiki).
 Contributions are best submitted via GitHub pull requests.
 
 If you get stuck anywhere in the process, please do not hestitate to ask us anytime at info@opacapp.de.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Web Opac App [![Build Status](https://travis-ci.org/opacapp/opacclient.svg?branch=master)](https://travis-ci.org/opacapp/opacclient)
+Web Opac App [![Build Status](https://travis-ci.org/opacapp/opacclient.svg?branch=master)](https://travis-ci.org/opacapp/opacclient)[![Coverage Status](https://coveralls.io/repos/github/opacapp/opacclient/badge.svg?branch=master)](https://coveralls.io/github/opacapp/opacclient?branch=master)
 ============
 Android client for public libraries. See [opacapp.net](http://opacapp.net) for details.
 

--- a/opacclient/build.gradle
+++ b/opacclient/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.4.0'
     }
 }
 

--- a/opacclient/libopac/build.gradle
+++ b/opacclient/libopac/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+apply plugin: 'jacoco'
+apply plugin: 'com.github.kt3k.coveralls'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -16,6 +18,13 @@ dependencies {
 task copyTestResources(type: Copy) {
     from "${projectDir}/src/test/resources"
     into "${buildDir}/classes/test"
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
 }
 
 processTestResources.dependsOn copyTestResources

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Bibliotheca.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Bibliotheca.java
@@ -277,6 +277,7 @@ public class Bibliotheca extends BaseApi {
         nameValuePairs.add(new BasicNameValuePair("stichtit", "stich"));
 
         int ifeldCount = 0;
+        String order = "asc";
         for (SearchQuery query : queries) {
             if (query.getValue().equals("")) {
                 continue;
@@ -296,8 +297,7 @@ public class Bibliotheca extends BaseApi {
             if (key.equals("orderselect") && query.getValue().contains(":")) {
                 nameValuePairs.add(new BasicNameValuePair("orderselect", query
                         .getValue().split(":")[0]));
-                nameValuePairs.add(new BasicNameValuePair("order", query
-                        .getValue().split(":")[1]));
+                order = query.getValue().split(":")[1];
             } else {
                 nameValuePairs
                         .add(new BasicNameValuePair(key, query.getValue()));
@@ -331,6 +331,9 @@ public class Bibliotheca extends BaseApi {
 
         String html = httpPost(opac_url + "/index.asp",
                 new UrlEncodedFormEntity(nameValuePairs), getDefaultEncoding());
+        if (html.contains("<a href=\"index.asp?order=" + order + "\">")) {
+            html = httpGet(opac_url + "/index.asp?order=" + order, getDefaultEncoding());
+        }
         return parse_search(html, 1);
     }
 

--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.3.1'
     debugCompile 'com.facebook.stetho:stetho:1.3.1'
     debugCompile 'com.facebook.stetho:stetho-okhttp3:1.3.1'
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'
 
     // We don't want to rely on the CommonsWare Maven repo, so we include these libraries as JARs
     compile files('libs/adapter-1.0.1.jar')

--- a/opacclient/opacapp/src/debug/java/de/geeksfactory/opacclient/utils/DebugTools.java
+++ b/opacclient/opacapp/src/debug/java/de/geeksfactory/opacclient/utils/DebugTools.java
@@ -4,12 +4,14 @@ import android.app.Application;
 
 import com.facebook.stetho.Stetho;
 import com.facebook.stetho.okhttp3.StethoInterceptor;
+import com.squareup.leakcanary.LeakCanary;
 
 import okhttp3.OkHttpClient;
 
 public class DebugTools {
     public static void init(Application app) {
         Stetho.initializeWithDefaults(app);
+        LeakCanary.install(app);
     }
 
     public static OkHttpClient.Builder prepareHttpClient(OkHttpClient.Builder builder) {


### PR DESCRIPTION
- Fixed search using Bibliotheca not working the first time when the sorting field was used
- Added test coverage report for libopac tests, will be uploaded to https://coveralls.io/ using Travis CI. #434 also adds these reports for the reminder unit tests.
- Added "Leak Canary" library for debug builds (currently detects no leaks)