### PR TITLE
Don't crash when last_library_config_update.txt is missing from the APK

### DIFF
--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/OpacClient.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/OpacClient.java
@@ -39,6 +39,7 @@ import com.commonsware.cwac.wakeful.WakefulIntentService;
 import org.acra.ACRA;
 import org.acra.ACRAConfiguration;
 import org.acra.annotation.ReportsCrashes;
+import org.joda.time.DateTime;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -381,9 +382,10 @@ public class OpacClient extends Application {
                 ACRA.getErrorReporter().putCustomData("library",
                         getLibrary().getIdent());
             }
+            DateTime lastUpdate = new PreferenceDataSource(getApplicationContext())
+                    .getLastLibraryConfigUpdate();
             ACRA.getErrorReporter().putCustomData("data_version",
-                    (new PreferenceDataSource(getApplicationContext())).getLastLibraryConfigUpdate()
-                                                                       .toString());
+                    lastUpdate != null ? lastUpdate.toString() : "null");
         }
         DebugTools.init(this);
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
@@ -831,8 +831,7 @@ public class LibraryListActivity extends AppCompatActivity
                         ACRA.getErrorReporter().putCustomData("data_version",
                                 prefs.getLastLibraryConfigUpdate().toString());
                     }
-                } catch (IOException | JSONException e) {
-                    e.printStackTrace();
+                } catch (IOException | JSONException ignore) {
                     // fail silently (e.g. when no Internet connection available)
                 }
             }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainPreferenceFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/MainPreferenceFragment.java
@@ -207,10 +207,15 @@ public class MainPreferenceFragment extends PreferenceFragmentCompat {
 
     private void refreshLastConfigUpdate(Preference updateLibraryConfig) {
         DateTime lastUpdate = new PreferenceDataSource(context).getLastLibraryConfigUpdate();
-        CharSequence lastUpdateStr =
-                DateUtils.getRelativeTimeSpanString(context, lastUpdate.getMillis(), true);
-        updateLibraryConfig
-                .setSummary(getString(R.string.library_config_last_update, lastUpdateStr));
+        if (lastUpdate != null) {
+            CharSequence lastUpdateStr =
+                    DateUtils.getRelativeTimeSpanString(context, lastUpdate.getMillis(), true);
+            updateLibraryConfig
+                    .setSummary(getString(R.string.library_config_last_update, lastUpdateStr));
+        } else {
+            updateLibraryConfig
+                    .setSummary(getString(R.string.library_config_last_update_never));
+        }
     }
 
     private void showDialog(DialogFragment newFragment) {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/AccountAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/AccountAdapter.java
@@ -126,16 +126,16 @@ public abstract class AccountAdapter<I extends AccountItem, VH extends AccountAd
                          .into(ivCover);
                 } else {
                     ivCover.setVisibility(View.GONE);
-                    ivMediaType.setVisibility(View.VISIBLE);
                     Glide.clear(ivCover);
-                }
-                if (item.getMediaType() != null) {
-                    ivMediaType.setImageResource(
-                            ResultsAdapter.getResourceByMediaType(item.getMediaType
-                                    ()));
-                    ivMediaType.setContentDescription(sp.getMediaTypeName(item.getMediaType()));
-                } else {
-                    ivMediaType.setVisibility(View.INVISIBLE);
+                    if (item.getMediaType() != null) {
+                        ivMediaType.setImageResource(
+                                ResultsAdapter.getResourceByMediaType(item.getMediaType
+                                        ()));
+                        ivMediaType.setContentDescription(sp.getMediaTypeName(item.getMediaType()));
+                        ivMediaType.setVisibility(View.VISIBLE);
+                    } else {
+                        ivMediaType.setVisibility(View.INVISIBLE);
+                    }
                 }
             }
         }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/AccountAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/AccountAdapter.java
@@ -4,9 +4,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.support.graphics.drawable.VectorDrawableCompat;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
-import android.text.Html;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.ImageButton;
@@ -151,16 +149,9 @@ public abstract class AccountAdapter<I extends AccountItem, VH extends AccountAd
         }
     }
 
-    protected static void setHtmlTextOrHide(String value, TextView tv) {
-        if (!TextUtils.isEmpty(value)) {
-            tv.setText(Html.fromHtml(value));
-        } else {
-            tv.setVisibility(View.GONE);
-        }
-    }
-
     protected static void setTextOrHide(CharSequence value, TextView tv) {
         if (!TextUtils.isEmpty(value)) {
+            tv.setVisibility(View.VISIBLE);
             tv.setText(value);
         } else {
             tv.setVisibility(View.GONE);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/ReservationsAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/ReservationsAdapter.java
@@ -59,18 +59,14 @@ public class ReservationsAdapter
                 }
             }
             if (item.getReadyDate() != null) {
-                status.append(context.getString(R.string.reservation_expire_until)).append(" ")
-                      .append(fmt.print(item.getReadyDate()));
+                status.append(fmt.print(item.getReadyDate()));
             }
             if (item.getExpirationDate() != null) {
                 if (item.getReadyDate() != null) status.append(", ");
-                status.append(fmt.print(item.getExpirationDate()));
+                status.append(context.getString(R.string.reservation_expire_until)).append(" ")
+                      .append(fmt.print(item.getExpirationDate()));
             }
-            if (status.length() > 0) {
-                tvStatus.setText(status);
-            } else {
-                tvStatus.setVisibility(View.GONE);
-            }
+            setTextOrHide(status, tvStatus);
 
             ivProlong.setVisibility(View.GONE);
             ivDownload.setVisibility(View.GONE);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/SyncAccountService.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/SyncAccountService.java
@@ -31,7 +31,6 @@ import com.commonsware.cwac.wakeful.WakefulIntentService;
 
 import org.acra.ACRA;
 import org.joda.time.DateTime;
-import org.joda.time.Duration;
 import org.joda.time.Hours;
 import org.json.JSONException;
 
@@ -49,7 +48,6 @@ import de.geeksfactory.opacclient.storage.AccountDataSource;
 import de.geeksfactory.opacclient.storage.JsonSearchFieldDataSource;
 import de.geeksfactory.opacclient.storage.PreferenceDataSource;
 import de.geeksfactory.opacclient.webservice.LibraryConfigUpdateService;
-import de.geeksfactory.opacclient.webservice.UpdateHandler;
 import de.geeksfactory.opacclient.webservice.WebService;
 import de.geeksfactory.opacclient.webservice.WebServiceManager;
 
@@ -131,7 +129,7 @@ public class SyncAccountService extends WakefulIntentService {
                 ACRA.getErrorReporter().putCustomData("data_version",
                         prefs.getLastLibraryConfigUpdate().toString());
             }
-        } catch (IOException | JSONException e) {
+        } catch (IOException | JSONException ignore) {
 
         }
     }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/PreferenceDataSource.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/PreferenceDataSource.java
@@ -21,6 +21,7 @@ package de.geeksfactory.opacclient.storage;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
 
 import org.joda.time.DateTime;
 
@@ -48,6 +49,7 @@ public class PreferenceDataSource {
         sp = PreferenceManager.getDefaultSharedPreferences(context);
     }
 
+    @Nullable
     public DateTime getLastLibraryConfigUpdate() {
         String lastUpdate = sp.getString(LAST_LIBRARY_CONFIG_UPDATE, null);
         if (lastUpdate == null || getLastLibraryConfigUpdateVersion() != BuildConfig.VERSION_CODE) {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/webservice/LibraryConfigUpdateService.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/webservice/LibraryConfigUpdateService.java
@@ -25,6 +25,7 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import org.acra.ACRA;
+import org.joda.time.DateTime;
 import org.json.JSONException;
 
 import java.io.File;
@@ -58,8 +59,9 @@ public class LibraryConfigUpdateService extends IntentService {
             int count = ((OpacClient) getApplication()).getUpdateHandler().updateConfig(
                     service, prefs, new FileOutput(filesDir), new JsonSearchFieldDataSource(this));
             if (!BuildConfig.DEBUG) {
-                ACRA.getErrorReporter().putCustomData("data_version",
-                        prefs.getLastLibraryConfigUpdate().toString());
+                DateTime lastUpdate = prefs.getLastLibraryConfigUpdate();
+                ACRA.getErrorReporter().putCustomData("data_version", lastUpdate != null ?
+                        lastUpdate.toString() : "null");
             }
             if (BuildConfig.DEBUG) {
                 Log.d("LibraryConfigUpdate",

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/webservice/UpdateHandler.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/webservice/UpdateHandler.java
@@ -28,6 +28,10 @@ public class UpdateHandler {
         Response<List<Library>>
                 response = service.getLibraryConfigs(prefs.getLastLibraryConfigUpdate(),
                 BuildConfig.VERSION_CODE, 0, null).execute();
+        if (!response.isSuccessful()) {
+            throw new IOException(String.valueOf(response.code()));
+        }
+
         List<Library> updatedLibraries = response.body();
 
         for (Library lib : updatedLibraries) {

--- a/opacclient/opacapp/src/main/res/values-de/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-de/strings.xml
@@ -298,6 +298,7 @@
     <string name="library_config_update_success">Daten für %d Bibliotheken aktualisiert.</string>
     <string name="library_config_update_failure">Konnte Bibliotheksdaten nicht aktualisieren.</string>
     <string name="library_config_last_update">Zuletzt aktualisiert %s</string>
+    <string name="library_config_last_update_never">Noch keine Daten geladen</string>
     <string name="library_config_reset">Bibliotheksdaten vom letzten App-Update wiederhergestellt.</string>
     <string name="library_removed_error">Ihre Bibliothek wurde leider aus der App entfernt. Gründe dafür könnten sein, dass die Bibliothek zu einer anderen Software gewechselt hat, mit der die App nicht kompatibel ist, oder, dass die Bibliothek uns direkt kontaktiert hat und explizit darum gebeten hat, aus der App entfernt zu werden. Für weitere Informationen können Sie uns unter info@opacapp.net kontaktieren.</string>
     <string name="account_anonymous">anonym (nur Suche)</string>

--- a/opacclient/opacapp/src/main/res/values/strings.xml
+++ b/opacclient/opacapp/src/main/res/values/strings.xml
@@ -295,6 +295,7 @@
     <string name="library_config_update_success">Updated data for %d libraries.</string>
     <string name="library_config_update_failure">Could not update library data.</string>
     <string name="library_config_last_update">Last updated %s</string>
+    <string name="library_config_last_update_never">No data downloaded yet</string>
     <string name="library_config_reset">Restored library data from last app update.</string>
     <string name="library_removed_error">Unfortunately, the library you are using was removed from the app. The reason for this could be that the library switched to a new software system that the app is not compatible with or that the library contacted us and explicitly stated that they want to be removed from the app. You can contact us at info@opacapp.net to find out more.</string>
     <string name="account_anonymous">anonymous (search only)</string>


### PR DESCRIPTION
In release builds this situation normally should not appear (but it currently does with F-Droid builds, see #457). But this is also helpful for making debug builds possible without running `downloadJson` first.