### PR TITLE
Bibliotheca: Add title search field

### DIFF
--- a/opacclient/libopac/src/main/resources/meanings/general.json
+++ b/opacclient/libopac/src/main/resources/meanings/general.json
@@ -322,7 +322,8 @@
         "title (keywords)",
         "title words",
         "Mots titre",
-        "Titelwort/Thema"
+        "Titelwort/Thema",
+        "Titelanfang"
     ],
     "DIGITAL": [
         "digital",


### PR DESCRIPTION
Bibliotheca libraries (at least some of them, e.g. Bielefeld and Mannheim) have a search field called "Titel" combined with two radio buttons that allow you to select either "Stichwörter" or "Titelanfang". Until now, we only supported "Stichwörter".

A user requested that we should also have a real title seach field. So with this PR, a field is added that allows you to use "Titelanfang".

@raphaelm, you are probably more familiar with Bibliotheca. Do you think this will break anything? I tested it in Bielefeld and it seems to work there.