### PR TITLE
Adis: fixes for Stuttgart

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Adis.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Adis.java
@@ -20,6 +20,7 @@ import java.io.InterruptedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -98,7 +99,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
     protected int s_requestCount = 0;
     protected String s_service;
     protected String s_sid;
-    protected String s_exts;
+    protected List<String> s_exts;
     protected String s_alink;
     protected List<NameValuePair> s_pageform;
     protected int s_lastpage;
@@ -261,15 +262,17 @@ public class Adis extends ApacheBaseApi implements OpacApi {
 
             Pattern padSid = Pattern
                     .compile(".*;jsessionid=([0-9A-Fa-f]+)[^0-9A-Fa-f].*");
-            for (Element navitem : doc.select("#unav li a, .tree_ul li a")) {
+            for (Element navitem : doc
+                    .select("#unav li a, #hnav li a, .tree_ul li a, .search-adv-repeat")) {
                 // Düsseldorf uses a custom layout where the navbar is .tree_ul
+                // in Stuttgart, the navbar is #hnav and advanced search is linked outside the
+                // navbar as .search-adv-repeat
                 if (navitem.attr("href").contains("service=")) {
                     s_service = getQueryParams(navitem.attr("href")).get(
                             "service").get(0);
                 }
                 if (navitem.text().contains("Erweiterte Suche")) {
-                    s_exts = getQueryParams(navitem.attr("href")).get("sp")
-                                                                 .get(0);
+                    s_exts = getQueryParams(navitem.attr("href")).get("sp");
                 }
                 Matcher objid_matcher = padSid.matcher(navitem.attr("href"));
                 if (objid_matcher.matches()) {
@@ -277,7 +280,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
                 }
             }
             if (s_exts == null) {
-                s_exts = "SS6";
+                s_exts = Collections.singletonList("SS6");
             }
 
         } catch (JSONException e) {
@@ -299,7 +302,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
         // s_exts=SS2 instead of s_exts=SS6
         // e.g. munich. Treat them differently!
         Document doc = htmlGet(opac_url + ";jsessionid=" + s_sid + "?service="
-                + s_service + "&sp=" + s_exts);
+                + s_service + getSpParams());
 
         int dropdownTextCount = 0;
         int totalCount = 0;
@@ -325,7 +328,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
 
                 dropdownTextCount++;
 
-                if (s_exts.equals("SS2")
+                if (s_exts.get(0).equals("SS2")
                         || (query.getSearchField().getData() != null && !query
                         .getSearchField().getData()
                         .optBoolean("selectable", true))) {
@@ -371,6 +374,29 @@ public class Adis extends ApacheBaseApi implements OpacApi {
                 nvpairs);
 
         return parse_search_wrapped(docresults, 1);
+    }
+
+    private String getSpParams() {
+        return getSpParams(null);
+    }
+
+    private String getSpParams(String overrideSecond) {
+        if (overrideSecond != null && s_exts.size() == 1) {
+            return "&sp=" + overrideSecond;
+        }
+
+        StringBuilder builder = new StringBuilder();
+        int i = 0;
+        for (String sp : s_exts) {
+            builder.append("&sp=");
+            if (i == 1 && overrideSecond != null) {
+                builder.append(overrideSecond);
+            } else {
+                builder.append(sp);
+            }
+            i++;
+        }
+        return builder.toString();
     }
 
     public class SingleResultFound extends Exception {
@@ -1016,7 +1042,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
 
         start();
         doc = htmlGet(opac_url + ";jsessionid=" + s_sid + "?service="
-                + s_service + "&sp=SBK");
+                + s_service + getSpParams("SBK"));
         try {
             doc = handleLoginForm(doc, account);
         } catch (OpacErrorException e) {
@@ -1095,7 +1121,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
         Document doc;
         start();
         doc = htmlGet(opac_url + ";jsessionid=" + s_sid + "?service="
-                + s_service + "&sp=SBK");
+                + s_service + getSpParams("SBK"));
         try {
             doc = handleLoginForm(doc, account);
         } catch (OpacErrorException e) {
@@ -1169,7 +1195,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
         rlink = media.split("\\|")[1].replace("requestCount=", "fooo=");
         start();
         doc = htmlGet(opac_url + ";jsessionid=" + s_sid + "?service="
-                + s_service + "&sp=SBK");
+                + s_service + getSpParams("SBK"));
         try {
             doc = handleLoginForm(doc, account);
         } catch (OpacErrorException e) {
@@ -1239,7 +1265,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
         start();
 
         Document doc = htmlGet(opac_url + ";jsessionid=" + s_sid + "?service="
-                + s_service + "&sp=SBK");
+                + s_service + getSpParams("SBK"));
         doc = handleLoginForm(doc, account);
 
         boolean split_title_author = true;
@@ -1545,8 +1571,8 @@ public class Adis extends ApacheBaseApi implements OpacApi {
 
         doc = htmlPost(opac_url + ";jsessionid=" + s_sid, form);
 
-        if (doc.select(".message h1").size() > 0) {
-            String msg = doc.select(".message h1").text().trim();
+        if (doc.select(".message h1, .alert").size() > 0) {
+            String msg = doc.select(".message h1, .alert").text().trim();
             form = new ArrayList<>();
             for (Element input : doc.select("input")) {
                 if (!"image".equals(input.attr("type"))
@@ -1574,7 +1600,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
         }
 
         Document doc = htmlGet(opac_url + ";jsessionid=" + s_sid + "?service="
-                + s_service + "&sp=" + s_exts);
+                + s_service + getSpParams());
 
         List<SearchField> fields = new ArrayList<>();
         // dropdown to select which field you want to search in
@@ -1709,7 +1735,7 @@ public class Adis extends ApacheBaseApi implements OpacApi {
         start();
 
         Document doc = htmlGet(opac_url + ";jsessionid=" + s_sid + "?service="
-                + s_service + "&sp=SBK");
+                + s_service + getSpParams("SBK"));
         handleLoginForm(doc, account);
     }
 


### PR DESCRIPTION
Stadtbibliothek Stuttgart now switched from their previous OPAC (Bibliotheca 2.4), which we didn't support, to aDIS.
https://opac.sbs.stuttgart.de/aDISWeb/app?service=direct/0/Home/$DirectLink&sp=SOPAC

There were a few problems that lead to our API not being able to load the advanced search form (and therefore to parse the search fields) in this aDIS instance. I don't really understand why they use the "&sp=" parameter twice (with different values) in their URLs, but it seems to be necessary to get the right response. I'm not that familiar with the aDIS API, so it might be quite a "quick-and-dirty" fix 😉 

Account features could not be tested, just that entering wrong credentials correctly results in an error message.

One search field that is still not shown in the app is the "Sie suchen in der Bibliothek:" search field, which is formatted differently than the others. @raphaelm , could you take a look at that?

I have already added the config file for the app into our system so that it will be included with the next app version (version code 184).