### PR TITLE
OkHttpBaseApi: Replace our hacky asyncWait implementation with CompletableFutures

### DIFF
--- a/opacclient/libopac/build.gradle
+++ b/opacclient/libopac/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'java'
 apply plugin: 'jacoco'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
@@ -14,6 +14,7 @@ dependencies {
     compile 'joda-time:joda-time:2.8.2'
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
     compile "com.squareup.okhttp3:okhttp-urlconnection:3.9.0"
+    compile 'net.sourceforge.streamsupport:streamsupport-cfuture:1.6.0'
     testCompile "junit:junit:4.12"
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'jacoco'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '27.0.2'
 
     defaultConfig {
         applicationId "de.geeksfactory.opacclient"
@@ -45,8 +45,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
         encoding 'UTF-8'
     }
 
@@ -99,6 +99,7 @@ dependencies {
     compile 'com.github.bumptech.glide:glide:3.8.0'
     compile 'com.github.bumptech.glide:okhttp3-integration:1.5.0@aar'
     compile 'com.evernote:android-job:1.2.0'
+    compile 'net.sourceforge.streamsupport:streamsupport-cfuture:1.6.0'
     debugCompile 'com.facebook.stetho:stetho:1.5.0'
     debugCompile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
     debugCompile 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'

--- a/opacclient/opacapp/proguard-rules.txt
+++ b/opacclient/opacapp/proguard-rules.txt
@@ -49,3 +49,8 @@
 
 # Apache
 #-dontwarn org.apache.**
+
+# streamsupport
+# https://github.com/streamsupport/streamsupport/blob/master/streamsupport-pro/streamsupport.pro
+-keep class java8.** { *; }
+-dontwarn java8.**


### PR DESCRIPTION
With this, we can wait for the requests we actually need instead of all requests that are currently executed by OkHttp (which might happen if something is called concurrently).

this also makes libopac depend on Java 8

Still, we need to use the [streamsupport](https://sourceforge.net/projects/streamsupport/) library to be compatible with Android - the Android build system does backport lambdas, but not CompletableFutures and the stream API.