### PR TITLE
Add option to disable loading of covers on mobile data

### DIFF
--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapter.java
@@ -22,7 +22,9 @@
 package de.geeksfactory.opacclient.frontend;
 
 import android.content.Context;
+import android.net.ConnectivityManager;
 import android.support.annotation.DrawableRes;
+import android.support.v4.net.ConnectivityManagerCompat;
 import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -44,6 +46,7 @@ import de.geeksfactory.opacclient.networking.CoverDownloadTask;
 import de.geeksfactory.opacclient.objects.CoverHolder;
 import de.geeksfactory.opacclient.objects.SearchResult;
 import de.geeksfactory.opacclient.objects.SearchResult.MediaType;
+import de.geeksfactory.opacclient.storage.PreferenceDataSource;
 import de.geeksfactory.opacclient.utils.BitmapUtils;
 
 public class ResultsAdapter extends ArrayAdapter<SearchResult> {
@@ -150,10 +153,16 @@ public class ResultsAdapter extends ArrayAdapter<SearchResult> {
 
         ImageView ivType = (ImageView) view.findViewById(R.id.ivType);
 
+        PreferenceDataSource pds = new PreferenceDataSource(getContext());
+        ConnectivityManager connMgr =
+                (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+
         if (item.getCoverBitmap() != null) {
             ivType.setImageBitmap(BitmapUtils.bitmapFromBytes(item.getCoverBitmap()));
             ivType.setVisibility(View.VISIBLE);
-        } else if (item.getCover() != null) {
+        } else if ((pds.isLoadCoversOnDataPreferenceSet()
+                || !ConnectivityManagerCompat.isActiveNetworkMetered(connMgr))
+                && item.getCover() != null) {
             LoadCoverTask lct = new LoadCoverTask(ivType, item);
             lct.execute();
             ivType.setImageResource(R.drawable.ic_loading);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultDetailFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/SearchResultDetailFragment.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.net.ConnectivityManager;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -18,6 +19,7 @@ import android.print.PrintDocumentAdapter;
 import android.print.PrintManager;
 import android.support.design.widget.AppBarLayout;
 import android.support.v4.app.Fragment;
+import android.support.v4.net.ConnectivityManagerCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.graphics.Palette;
 import android.support.v7.widget.LinearLayoutManager;
@@ -75,6 +77,7 @@ import de.geeksfactory.opacclient.objects.Detail;
 import de.geeksfactory.opacclient.objects.DetailedItem;
 import de.geeksfactory.opacclient.objects.SearchResult;
 import de.geeksfactory.opacclient.storage.AccountDataSource;
+import de.geeksfactory.opacclient.storage.PreferenceDataSource;
 import de.geeksfactory.opacclient.storage.StarDataSource;
 import de.geeksfactory.opacclient.ui.AppCompatProgressDialog;
 import de.geeksfactory.opacclient.ui.WhitenessUtils;
@@ -1295,8 +1298,17 @@ public class SearchResultDetailFragment extends Fragment
 
             item = result;
 
+            PreferenceDataSource pds = new PreferenceDataSource(getContext());
+            ConnectivityManager connMgr =
+                    (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+
             if (item.getCover() != null && item.getCoverBitmap() == null) {
-                new LoadCoverTask(item, collapsingToolbar.getWidth(), collapsingToolbar.getHeight()).execute();
+                if ((pds.isLoadCoversOnDataPreferenceSet()
+                        || !ConnectivityManagerCompat.isActiveNetworkMetered(connMgr))) {
+                    new LoadCoverTask(item, collapsingToolbar.getWidth(),
+                            collapsingToolbar.getHeight()).execute();
+                }
+
             } else {
                 displayCover();
             }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/PreferenceDataSource.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/storage/PreferenceDataSource.java
@@ -20,8 +20,12 @@ package de.geeksfactory.opacclient.storage;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.preference.Preference;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
+import android.support.v7.preference.CheckBoxPreference;
+
 
 import org.joda.time.DateTime;
 
@@ -95,5 +99,9 @@ public class PreferenceDataSource {
 
     public void setLastLibraryConfigUpdateVersion(int lastUpdateVersion) {
         sp.edit().putInt(LAST_LIBRARY_CONFIG_UPDATE_VERSION, lastUpdateVersion).apply();
+    }
+
+    public boolean isLoadCoversOnDataPreferenceSet() {
+        return sp.getBoolean("on_data_load_covers", true);
     }
 }

--- a/opacclient/opacapp/src/main/res/xml/settings.xml
+++ b/opacclient/opacapp/src/main/res/xml/settings.xml
@@ -21,6 +21,11 @@
             android:key="email"
             android:summary="@string/email_address_description"
             android:title="@string/email_address"/>
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="on_data_load_covers"
+            android:title="Load covers while on mobile data"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/notifications">
         <CheckBoxPreference


### PR DESCRIPTION
Fixes #502 

As explained in the commit message:
```
There is no option to disable loading of covers while mobile data is switched on.

This is counterproductive for users who would prefer less data to be used when on a metered network.

As such, let's add an option to disable loading of covers while on mobile data.
```