### PR TITLE
Switch from ACRA to Sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build/
 # Local configuration file (sdk path, etc)
 local.properties
 ant.properties
+sentry.properties
 
 web/
 testproject/

--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -70,9 +70,7 @@ dependencies {
     implementation(project(':libopac')) {
         transitive = false
     }
-    implementation('ch.acra:acra:4.9.0') {
-        exclude group: 'org.json', module: 'json'
-    }
+    implementation 'io.sentry:sentry-android:1.7.4'
     implementation 'org.jsoup:jsoup:1.8.3'
     implementation 'com.android.support:design:27.1.1'
     implementation 'com.android.support:support-v4:27.1.1'
@@ -89,7 +87,7 @@ dependencies {
     implementation 'su.j2e:rv-joiner:1.0.6'
     implementation 'joda-time:joda-time:2.8.2'
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
-    implementation "com.squareup.okhttp3:okhttp-urlconnection:3.10.0"
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.10.0'
     implementation 'com.squareup.retrofit2:retrofit:2.3.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.1.0'
     implementation 'com.samskivert:jmustache:1.13'
@@ -106,7 +104,6 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:okhttp:3.10.0'
     testImplementation 'com.squareup.retrofit2:retrofit-mock:2.3.0'
     testImplementation 'commons-io:commons-io:2.5'
-
     // We don't want to rely on the CommonsWare Maven repo, so we include these libraries as JARs
     implementation files('libs/adapter-1.0.1.jar')
     implementation files('libs/endless-1.2.3.jar')

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/LibraryListActivity.java
@@ -41,7 +41,6 @@ import android.widget.SectionIndexer;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import org.acra.ACRA;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.json.JSONException;
@@ -71,6 +70,7 @@ import de.geeksfactory.opacclient.utils.ErrorReporter;
 import de.geeksfactory.opacclient.webservice.LibraryConfigUpdateService;
 import de.geeksfactory.opacclient.webservice.WebService;
 import de.geeksfactory.opacclient.webservice.WebServiceManager;
+import io.sentry.Sentry;
 
 public class LibraryListActivity extends AppCompatActivity
         implements ActivityCompat.OnRequestPermissionsResultCallback {
@@ -830,7 +830,7 @@ public class LibraryListActivity extends AppCompatActivity
                             "updated config for " + String.valueOf(count) + " libraries");
                     ((OpacClient) getApplication()).resetCache();
                     if (!BuildConfig.DEBUG) {
-                        ACRA.getErrorReporter().putCustomData("data_version",
+                        Sentry.getContext().addExtra(OpacClient.SENTRY_DATA_VERSION,
                                 prefs.getLastLibraryConfigUpdate().toString());
                     }
                 } catch (IOException | JSONException ignore) {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/SyncAccountJob.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/SyncAccountJob.java
@@ -28,7 +28,6 @@ import android.util.Log;
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobRequest;
 
-import org.acra.ACRA;
 import org.joda.time.DateTime;
 import org.joda.time.Hours;
 import org.json.JSONException;
@@ -50,6 +49,7 @@ import de.geeksfactory.opacclient.storage.PreferenceDataSource;
 import de.geeksfactory.opacclient.webservice.LibraryConfigUpdateService;
 import de.geeksfactory.opacclient.webservice.WebService;
 import de.geeksfactory.opacclient.webservice.WebServiceManager;
+import io.sentry.Sentry;
 
 public class SyncAccountJob extends Job {
 
@@ -165,7 +165,7 @@ public class SyncAccountJob extends Job {
             Log.d(TAG, "updated config for " + String.valueOf(count) + " libraries");
             getApp().resetCache();
             if (!BuildConfig.DEBUG) {
-                ACRA.getErrorReporter().putCustomData("data_version",
+                Sentry.getContext().addExtra(OpacClient.SENTRY_DATA_VERSION,
                         prefs.getLastLibraryConfigUpdate().toString());
             }
         } catch (IOException | JSONException ignore) {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/utils/ErrorReporter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/utils/ErrorReporter.java
@@ -1,18 +1,18 @@
 package de.geeksfactory.opacclient.utils;
 
-import org.acra.ACRA;
-
 import de.geeksfactory.opacclient.BuildConfig;
+import io.sentry.Sentry;
 
 /**
- * Helper class to delegate errors to ACRA in the release version and rethrow them in the debug version
+ * Helper class to delegate errors to Sentry in the release version and rethrow them in the debug
+ * version
  */
 public class ErrorReporter {
     public static void handleException(Throwable e) {
         if (BuildConfig.DEBUG) {
             throw new RuntimeException(e);
         } else {
-            ACRA.getErrorReporter().handleException(e);
+            Sentry.capture(e);
         }
     }
 }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/webservice/LibraryConfigUpdateService.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/webservice/LibraryConfigUpdateService.java
@@ -24,7 +24,6 @@ import android.content.Intent;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
-import org.acra.ACRA;
 import org.joda.time.DateTime;
 import org.json.JSONException;
 
@@ -37,6 +36,7 @@ import de.geeksfactory.opacclient.OpacClient;
 import de.geeksfactory.opacclient.storage.JsonSearchFieldDataSource;
 import de.geeksfactory.opacclient.storage.PreferenceDataSource;
 import de.geeksfactory.opacclient.utils.ErrorReporter;
+import io.sentry.Sentry;
 
 public class LibraryConfigUpdateService extends IntentService {
     private static final String NAME = "LibraryConfigUpdateService";
@@ -60,7 +60,7 @@ public class LibraryConfigUpdateService extends IntentService {
                     service, prefs, new FileOutput(filesDir), new JsonSearchFieldDataSource(this));
             if (!BuildConfig.DEBUG) {
                 DateTime lastUpdate = prefs.getLastLibraryConfigUpdate();
-                ACRA.getErrorReporter().putCustomData("data_version", lastUpdate != null ?
+                Sentry.getContext().addExtra(OpacClient.SENTRY_DATA_VERSION, lastUpdate != null ?
                         lastUpdate.toString() : "null");
             }
             if (BuildConfig.DEBUG) {


### PR DESCRIPTION
We had some problems with ACRA before, the version we currently use doesn't work for Android 8.0+, and we already use Sentry for other projects, so this PR implements the switch.

To make Sentry work, we additionally need to add a file named `sentry.properties` in `opacclient/opacapp/src/main/resources` with the content:

```
dsn=<insert DSN from Sentry here>
```

I haven't added this file to the Git repository to keep our DSN secret. If the file is not present, that's no problem, Sentry will just not send any reports (which it won't do in debug builds anyway).

Maybe we should document that the file needs to be present somewhere (I just don't know where) or even create some Gradle task that ensures that it is there when a release build is compiled, so that we don't forget it.

Currently, in addition to the stack traces, Sentry sends the library ID and data version (as ACRA did before). In addition, we could also use the "breadcrumbs" feature (e.g. for each Activity/Fragment shown), but I don't know if that's really useful.