### PR TITLE
Fix icon misaligned in landscape mode

### DIFF
--- a/opacclient/opacapp/src/main/res/layout/navigation_drawer_header.xml
+++ b/opacclient/opacapp/src/main/res/layout/navigation_drawer_header.xml
@@ -25,6 +25,35 @@
             android:src="@drawable/drawer_bg"/>
 
         <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignBottom="@id/imageView3"
+            android:layout_alignTop="@id/imageView3"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/ivLogo"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="true"
+                    android:maxWidth="72dp"
+                    android:maxHeight="72dp"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignParentStart="true"
+                    android:layout_alignParentTop="true"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="16dp"
+                    app:srcCompat="@drawable/ic_logo"/>
+
+            </LinearLayout>
+
+            <LinearLayout
             android:id="@+id/account_data"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -89,17 +118,7 @@
                 android:tint="#FFF"/>
         </LinearLayout>
 
-        <ImageView
-            android:id="@+id/ivLogo"
-            android:layout_width="72dp"
-            android:layout_height="72dp"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:layout_marginLeft="16dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            app:srcCompat="@drawable/ic_logo"/>
+        </LinearLayout>
 
     </RelativeLayout>
 

--- a/opacclient/opacapp/src/main/res/values/dimens.xml
+++ b/opacclient/opacapp/src/main/res/values/dimens.xml
@@ -7,7 +7,7 @@
     <dimen name="card_side_margin_selected">0dp</dimen>
     <dimen name="card_topbottom_margin_default">4dp</dimen>
     <dimen name="card_topbottom_margin_selected">2dp</dimen>
-    <dimen name="navigation_drawer_header_height">120dp</dimen>
+    <dimen name="navigation_drawer_header_height">160dp</dimen>
     <dimen name="list_top_padding">8dp</dimen>
     <dimen name="simple_search_padding">8dp</dimen>
     <dimen name="advanced_search_header_mtop">8dp</dimen>


### PR DESCRIPTION
Fixed icon size in relation to the space left and adjusted the top drawer height. No overlapping of the icon should occur in landscape mode anymore. 