### PR TITLE
Make status indicator circles accessible for color-blind people

### DIFF
--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapter.java
@@ -179,13 +179,13 @@ public class ResultsAdapter extends ArrayAdapter<SearchResult> {
             ivStatus.setVisibility(View.VISIBLE);
             switch (item.getStatus()) {
                 case GREEN:
-                    ivStatus.setImageResource(R.drawable.status_light_green);
+                    ivStatus.setImageResource(R.drawable.status_light_green_check);
                     break;
                 case RED:
-                    ivStatus.setImageResource(R.drawable.status_light_red);
+                    ivStatus.setImageResource(R.drawable.status_light_red_cross);
                     break;
                 case YELLOW:
-                    ivStatus.setImageResource(R.drawable.status_light_yellow);
+                    ivStatus.setImageResource(R.drawable.status_light_yellow_alert);
                     break;
                 case UNKNOWN:
                     ivStatus.setVisibility(View.INVISIBLE);

--- a/opacclient/opacapp/src/main/res/drawable/status_light_green_check.xml
+++ b/opacclient/opacapp/src/main/res/drawable/status_light_green_check.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/status_green"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/opacclient/opacapp/src/main/res/drawable/status_light_red_cross.xml
+++ b/opacclient/opacapp/src/main/res/drawable/status_light_red_cross.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/status_red"
+        android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+</vector>

--- a/opacclient/opacapp/src/main/res/drawable/status_light_yellow_alert.xml
+++ b/opacclient/opacapp/src/main/res/drawable/status_light_yellow_alert.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/status_yellow"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+</vector>

--- a/opacclient/opacapp/src/main/res/layout/listitem_searchresult.xml
+++ b/opacclient/opacapp/src/main/res/layout/listitem_searchresult.xml
@@ -19,8 +19,8 @@
 
     <ImageView
         android:id="@+id/ivStatus"
-        android:layout_width="10dp"
-        android:layout_height="10dp"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         android:visibility="gone"


### PR DESCRIPTION
Changed the status icons to make it more visible for color blind people. Adjusted also the size of the status indicators. The same colors were used as the one before. 