### PR TITLE
Improve lent item list format and add branch

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/objects/AccountItem.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/objects/AccountItem.java
@@ -102,7 +102,7 @@ public abstract class AccountItem implements Serializable {
 
     /**
      * @return status of an item. Some libraries use codes like "E" for "first lending period", "1"
-     * for "lending period extended once", etc. Optional.
+     * for "lending period extended once" etc. or strings like e.g. "2x verl., 1x reserv.".  Optional.
      */
     public String getStatus() {
         return status;
@@ -110,7 +110,7 @@ public abstract class AccountItem implements Serializable {
 
     /**
      * Set status of an item. Some libraries use codes like "E" for "first lending period", "1" for
-     * "lending period extended once", etc. Optional.
+     * "lending period extended once" etc. or strings like e.g. "2x verl., 1x reserv.". Optional.
      */
     public void setStatus(String status) {
         this.status = status;

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/AccountAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/AccountAdapter.java
@@ -71,6 +71,7 @@ public abstract class AccountAdapter<I extends AccountItem, VH extends AccountAd
         protected Context context;
         public TextView tvTitleAndAuthor;
         protected TextView tvStatus;
+        protected TextView tvBranch;
         protected View vStatusColor;
         protected ImageButton ivProlong;
         protected ImageButton ivDownload;
@@ -88,6 +89,7 @@ public abstract class AccountAdapter<I extends AccountItem, VH extends AccountAd
             this.context = itemView.getContext();
             tvTitleAndAuthor = (TextView) itemView.findViewById(R.id.tvTitleAndAuthor);
             tvStatus = (TextView) itemView.findViewById(R.id.tvStatus);
+            tvBranch = (TextView) itemView.findViewById(R.id.tvBranch);
             vStatusColor = itemView.findViewById(R.id.vStatusColor);
             ivProlong = (ImageButton) itemView.findViewById(R.id.ivProlong);
             ivDownload = (ImageButton) itemView.findViewById(R.id.ivDownload);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/AccountAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/AccountAdapter.java
@@ -2,10 +2,13 @@ package de.geeksfactory.opacclient.frontend.adapter;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v7.widget.RecyclerView;
+import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
+import android.text.style.StyleSpan;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -101,14 +104,17 @@ public abstract class AccountAdapter<I extends AccountItem, VH extends AccountAd
         }
 
         public void setItem(I item) {
-            // Overview (Title/Author, Status/Deadline)
-            if (item.getTitle() != null && item.getAuthor() != null) {
-                tvTitleAndAuthor.setText(item.getTitle() + ", " + item.getAuthor());
-            } else if (item.getTitle() != null) {
-                tvTitleAndAuthor.setText(item.getTitle());
-            } else {
-                setTextOrHide(item.getAuthor(), tvTitleAndAuthor);
+            // Overview (Title/Author, Status/Deadline, Branch)
+            SpannableStringBuilder builder = new SpannableStringBuilder();
+            if (item.getTitle() != null) {
+                builder.append(item.getTitle());
+                builder.setSpan(new StyleSpan(Typeface.BOLD), 0, item.getTitle().length(), 0);
+                if (!TextUtils.isEmpty(item.getAuthor())) builder.append(". ");
             }
+            if (!TextUtils.isEmpty(item.getAuthor())) {
+                builder.append(item.getAuthor().split("¬\\[",2)[0]);
+            }
+            setTextOrHide(builder, tvTitleAndAuthor);
 
             if (coversHidden) {
                 ivMediaType.setVisibility(View.GONE);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/LentAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/LentAdapter.java
@@ -69,6 +69,9 @@ public class LentAdapter extends AccountAdapter<LentItem, LentAdapter.ViewHolder
                 builder.append(Html.fromHtml(item.getStatus()));
             }
             setTextOrHide(builder, tvStatus);
+            if (item.getHomeBranch() != null) {
+                setTextOrHide(Html.fromHtml(item.getHomeBranch()), tvBranch);
+            }
 
             // Color codes for return dates
             if (item.getDeadline() != null) {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/LentAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/adapter/LentAdapter.java
@@ -10,6 +10,8 @@ import android.text.style.ForegroundColorSpan;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.widget.RelativeLayout;
 
 import org.joda.time.Days;
 import org.joda.time.LocalDate;
@@ -72,6 +74,24 @@ public class LentAdapter extends AccountAdapter<LentItem, LentAdapter.ViewHolder
             if (item.getHomeBranch() != null) {
                 setTextOrHide(Html.fromHtml(item.getHomeBranch()), tvBranch);
             }
+            tvBranch.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+                @Override
+                public boolean onPreDraw () {
+                    tvBranch.getViewTreeObserver().removeOnPreDrawListener(this);
+                    // place tvBranch next to or below tvStatus to prevent overlapping
+                    RelativeLayout.LayoutParams lp = (RelativeLayout.LayoutParams)tvBranch.getLayoutParams();
+                    if (tvStatus.getPaint().measureText(tvStatus.getText().toString()) <
+                            tvStatus.getWidth() / 2 - 4){
+                        lp.addRule(RelativeLayout.BELOW, 0);  //removeRule only since API 17
+                        lp.addRule(RelativeLayout.ALIGN_PARENT_TOP);
+                    } else {
+                        lp.addRule(RelativeLayout.ALIGN_PARENT_TOP,0);
+                        lp.addRule(RelativeLayout.BELOW, R.id.tvStatus);
+                    }
+                    tvBranch.setLayoutParams(lp);
+                    return true;
+                }
+            });
 
             // Color codes for return dates
             if (item.getDeadline() != null) {

--- a/opacclient/opacapp/src/main/res/layout/listitem_account_item.xml
+++ b/opacclient/opacapp/src/main/res/layout/listitem_account_item.xml
@@ -42,8 +42,6 @@
         android:layout_weight="1"
         android:layout_marginLeft="8dp"
         android:layout_marginStart="8dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginEnd="16dp"
         android:clickable="false"
         android:orientation="vertical"
         android:paddingBottom="4dp"

--- a/opacclient/opacapp/src/main/res/layout/listitem_account_item.xml
+++ b/opacclient/opacapp/src/main/res/layout/listitem_account_item.xml
@@ -61,14 +61,35 @@
             android:textSize="16sp"
             android:textColor="?android:attr/textColorPrimary"/>
 
-        <TextView
-            android:id="@+id/tvStatus"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:contentDescription="@string/status"
-            tools:text="27.09.2016 (Some status)"
-            android:textSize="14sp"
-            android:textColor="?android:attr/textColorSecondary"/>
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/tvStatus"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:contentDescription="@string/status"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="14sp"
+                tools:text="27.09.2016 (Some status)" />
+
+            <TextView
+                android:id="@+id/tvBranch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:contentDescription="@string/branch"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="14sp"
+                tools:text="Branch" />
+
+        </LinearLayout>
     </LinearLayout>
 
     <LinearLayout

--- a/opacclient/opacapp/src/main/res/layout/listitem_account_item.xml
+++ b/opacclient/opacapp/src/main/res/layout/listitem_account_item.xml
@@ -61,15 +61,21 @@
             android:textSize="16sp"
             android:textColor="?android:attr/textColorPrimary"/>
 
-        <LinearLayout
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:columnCount="2">
+            <Space
+                android:id="@+id/centerHelper"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_alignParentTop="true"
+                android:layout_centerHorizontal="true"/>
 
             <TextView
                 android:id="@+id/tvStatus"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
                 android:contentDescription="@string/status"
                 android:ellipsize="end"
                 android:maxLines="1"
@@ -79,17 +85,17 @@
 
             <TextView
                 android:id="@+id/tvBranch"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
+                android:visibility="gone"
+                android:layout_toRightOf="@id/centerHelper"
                 android:contentDescription="@string/branch"
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:textColor="?android:attr/textColorSecondary"
                 android:textSize="14sp"
                 tools:text="Branch" />
-
-        </LinearLayout>
+        </RelativeLayout>
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
Make items of lent items list look a bit nicer and clearer:
- Remove trailing delimiter for items without author (author string is empty but not null) (see second item in example below)
- Change title/author delimiter from ‘,’ to ‘.’ and print title in bold for better readability and clarity (see e.g. third item where is wasn't particularly clear where the title ends and the author starts)
- Remove details about person after ¬ sign (at least Dresden municipal library often has further information such as author, editor, producer etc. after the person's name) (see first and last item)

Add branch information to the list. I regularly borrow books from different branches of the same library. When I need to return a book I want to see what other books I hold from the same branch. This was only possible by clicking for details of each individual item which is quite cumbersome for a longer list.

![comparison](https://user-images.githubusercontent.com/19879328/48057652-d513af00-e1b4-11e8-8077-5b2e909e903e.jpg)


