### PR TITLE
Singular forms for expired items notification

### DIFF
--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/ReminderBroadcastReceiver.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/reminder/ReminderBroadcastReceiver.java
@@ -145,11 +145,12 @@ public class ReminderBroadcastReceiver extends BroadcastReceiver {
         // You can still return the item on the day it expires on, so don't consider it to have
         // expired before the next day
         if (alarm.deadline.isBefore(LocalDate.now())) {
-            notificationText = context
-                    .getString(R.string.notif_ticker_expired, expiringItems.size());
+            notificationText = context.getResources().getQuantityString(
+                    R.plurals.notif_ticker_expired, expiringItems.size(), expiringItems.size());
             notificationTitle = context.getString(R.string.notif_title_expired);
         } else {
-            notificationText = context.getString(R.string.notif_ticker, expiringItems.size());
+            notificationText = context.getResources().getQuantityString(
+                    R.plurals.notif_ticker, expiringItems.size(), expiringItems.size());
             notificationTitle = context.getString(R.string.notif_title);
         }
 

--- a/opacclient/opacapp/src/main/res/values-cs/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-cs/strings.xml
@@ -77,7 +77,18 @@
     </string-array>
     <string name="notification_warning">Perioda pro upozornění</string>
     <string name="notification_warning_desc">Jak dlouho dopředu chcete být upozorněni na blížící se datum vrácení?</string>
-    <string name="notif_ticker">u %d titulů se blíží datum vrácení!</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">U %d titulu se blíží datum vrácení!</item>
+        <item quantity="few">U %d titulů se blíží datum vrácení!</item>
+        <item quantity="other">U %d titulů se blíží datum vrácení!</item>
+    </plurals>
+    <string name="notif_title">Lhůta vrácení titulů se přiblížila</string>
+    <plurals name="notif_ticker_expired">
+        <item quantity="one">Lhůta vrácení %d titulu vypršela!</item>
+        <item quantity="few">Lhůta vrácení %d titulů vypršela!</item>
+        <item quantity="other">Lhůta vrácení %d titulů vypršela!</item>
+    </plurals>
+    <string name="notif_title_expired">Lhůta vrácení titulů vypršela</string>
     <string name="notif_snooze">Později</string>
     <string name="notif_dont_remind_again">Odmítnout</string>
     <string name="volumes">Čísla</string>

--- a/opacclient/opacapp/src/main/res/values-de/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-de/strings.xml
@@ -85,9 +85,15 @@
     </string-array>
     <string name="notification_warning">Warnzeitraum</string>
     <string name="notification_warning_desc">Wie lange vorher soll benachrichtigt werden?</string>
-    <string name="notif_ticker">%d Medien müssen abgegeben oder verlängert werden!</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">%d Medium muss abgegeben oder verlängert werden!</item>
+        <item quantity="other">%d Medien müssen abgegeben oder verlängert werden!</item>
+    </plurals>
     <string name="notif_title">Medien laufen ab</string>
-    <string name="notif_ticker_expired">%d Medien sind bereits abgelaufen!</string>
+    <plurals name="notif_ticker_expired">
+        <item quantity="one">%d Medium ist bereits abgelaufen!</item>
+        <item quantity="other">%d Medien sind bereits abgelaufen!</item>
+    </plurals>
     <string name="notif_title_expired">Medien sind abgelaufen</string>
     <string name="notif_plus_more">+%d weitere</string>
     <string name="notif_snooze">Später</string>

--- a/opacclient/opacapp/src/main/res/values-el/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-el/strings.xml
@@ -63,7 +63,10 @@
     <string name="startup_summary">Ποια οθόνη θα πρέπει να εμφανίζεται κατά την εκκίνηση;</string>
     <string name="notification_warning">Περίοδος προειδοποίησης</string>
     <string name="notification_warning_desc">Πόσο διάστημα πριν από την καταληκτική ημερομηνία θα πρέπει να παρουσιάζεται μια κοινοποίηση;</string>
-    <string name="notif_ticker">%d στοιχεία που πρόκειται να λήξουν!</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">%d στοιχείo που πρόκειται να λήξουν!</item>
+        <item quantity="other">%d στοιχεία που πρόκειται να λήξουν!</item>
+    </plurals>
     <string name="notif_title">Στοιχεία που πρόκειται να λήξουν</string>
     <string name="volumes">Τόμοι</string>
     <string name="volumesearch">Εμφάνιση τόμων</string>

--- a/opacclient/opacapp/src/main/res/values-es/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-es/strings.xml
@@ -83,9 +83,15 @@
     </string-array>
     <string name="notification_warning">Plazo de aviso</string>
     <string name="notification_warning_desc">¿Cuánto tiempo antes de la fecha de vencimiento quieres recibir un aviso?</string>
-    <string name="notif_ticker">¡%d artículos están a punto de expirar!</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">¡%d artículo está a punto de expirar!</item>
+        <item quantity="other">¡%d artículos están a punto de expirar!</item>
+    </plurals>
     <string name="notif_title">Artículos están a punto de expirar</string>
-    <string name="notif_ticker_expired">¡%d artículos han expirado!</string>
+    <plurals name="notif_ticker_expired">
+        <item quantity="one">¡%d artículo ha expirado!</item>
+        <item quantity="other">¡%d artículos han expirado!</item>
+    </plurals>
     <string name="notif_title_expired">Los artículos han expirado.</string>
     <string name="notif_plus_more">+%d más</string>
     <string name="notif_snooze">Más tarde</string>

--- a/opacclient/opacapp/src/main/res/values-fr/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-fr/strings.xml
@@ -83,9 +83,15 @@
     </string-array>
     <string name="notification_warning">Période d\'alerte</string>
     <string name="notification_warning_desc">Combien de temps avant la date d\'échéance la notification doit-elle être affichée?</string>
-    <string name="notif_ticker">%d articles sont sur le point d\'expirer!</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">%d article est sur le point d\'expirer!</item>
+        <item quantity="other">%d articles sont sur le point d\'expirer!</item>
+    </plurals>
     <string name="notif_title">Des articles sont sur le point d\'expirer</string>
-    <string name="notif_ticker_expired">%d articles ont expiré !</string>
+    <plurals name="notif_ticker_expired">
+        <item quantity="one">%d article a expiré!</item>
+        <item quantity="other">%d articles ont expiré!</item>
+    </plurals>
     <string name="notif_title_expired">Des articles ont expiré</string>
     <string name="notif_plus_more">et %d de plus</string>
     <string name="notif_snooze">Plus tard</string>

--- a/opacclient/opacapp/src/main/res/values-it/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-it/strings.xml
@@ -83,9 +83,15 @@
     </string-array>
     <string name="notification_warning">Preavviso</string>
     <string name="notification_warning_desc">Quanto tempo prima vuoi ricevere il promemoria?</string>
-    <string name="notif_ticker">%d libri sono in scadenza!</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">%d libro è in scadenza!</item>
+        <item quantity="other">%d libri sono in scadenza!</item>
+    </plurals>
     <string name="notif_title">Libri in scadenza</string>
-    <string name="notif_ticker_expired">%d prestiti sono scaduti!</string>
+    <plurals name="notif_ticker_expired">
+        <item quantity="one">%d prestito è scaduto!</item>
+        <item quantity="other">%d prestiti sono scaduti!</item>
+    </plurals>
     <string name="notif_title_expired">Prestiti scaduti</string>
     <string name="notif_plus_more">+%d ulteriori</string>
     <string name="notif_snooze">Dopo</string>

--- a/opacclient/opacapp/src/main/res/values-ja/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-ja/strings.xml
@@ -83,9 +83,13 @@
     </string-array>
     <string name="notification_warning">警告時期</string>
     <string name="notification_warning_desc">期限のどれくらい前に警告を表示しますか?</string>
-    <string name="notif_ticker">%d 本の期限です!</string>
+    <plurals name="notif_ticker">
+        <item quantity="other">%d 本の期限です!</item>
+    </plurals>
     <string name="notif_title">本の期限です</string>
-    <string name="notif_ticker_expired">%d 冊の期限が過ぎました!</string>
+    <plurals name="notif_ticker_expired">
+        <item quantity="other">%d 冊の期限が過ぎました!</item>
+    </plurals>
     <string name="notif_title_expired">本の期限が過ぎました</string>
     <string name="notif_plus_more">さらに +%d</string>
     <string name="notif_snooze">後で</string>

--- a/opacclient/opacapp/src/main/res/values-pl/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-pl/strings.xml
@@ -83,9 +83,19 @@
     </string-array>
     <string name="notification_warning">Okres ostrzeżenia</string>
     <string name="notification_warning_desc">Jak długo przed przedawnieniem powinno być pokazane powiadomienie.</string>
-    <string name="notif_ticker">%d pozycji wkrótce wygaśnie.</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">%d pozycja wkrótce wygaśnie.</item>
+        <item quantity="few">%d pozycje wkrótce wygasną.</item>
+        <item quantity="many">%d pozycji wkrótce wygaśnie.</item>
+        <item quantity="other">%d pozycje wkrótce wygaśnie.</item>
+    </plurals>
     <string name="notif_title">Pozycje które wygasają</string>
-    <string name="notif_ticker_expired">%d pozycji wygasło!</string>
+    <plurals name="notif_ticker_expired">
+        <item quantity="one">%d pozycja wygasła!</item>
+        <item quantity="few">%d pozycje wygasły!</item>
+        <item quantity="many">%d pozycji wygasło!</item>
+        <item quantity="other">%d pozycje wygasły!</item>
+    </plurals>
     <string name="notif_title_expired">Pozycje wygasły</string>
     <string name="notif_plus_more">+%d więcej</string>
     <string name="notif_snooze">Później</string>

--- a/opacclient/opacapp/src/main/res/values-tr/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-tr/strings.xml
@@ -83,7 +83,10 @@
     </string-array>
     <string name="notification_warning">Uyarı periyodu</string>
     <string name="notification_warning_desc">Zaman dolmadan ne kadar önce bildirim almak istersiniz?</string>
-    <string name="notif_ticker">%d öğenin geri verme zamanı yaklaştı!</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">%d öğenin geri verme zamanı yaklaştı!</item>
+        <item quantity="other">%d öğenin geri verme zamanı yaklaştı!</item>
+    </plurals>
     <string name="notif_title">Öğelerin geri verme zamanı yaklaştı</string>
     <string name="notif_title_expired">Zamanı geçen ögeler</string>
     <string name="notif_plus_more">+%d daha</string>

--- a/opacclient/opacapp/src/main/res/values/strings.xml
+++ b/opacclient/opacapp/src/main/res/values/strings.xml
@@ -85,9 +85,15 @@
     </string-array>
     <string name="notification_warning">Warning period</string>
     <string name="notification_warning_desc">How long before the due date should a notification be shown?</string>
-    <string name="notif_ticker">%d items are about to expire!</string>
+    <plurals name="notif_ticker">
+        <item quantity="one">%d item is about to expire!</item>
+        <item quantity="other">%d items are about to expire!</item>
+    </plurals>
     <string name="notif_title">Items are about to expire</string>
-    <string name="notif_ticker_expired">%d items have expired!</string>
+    <plurals name="notif_ticker_expired">
+        <item quantity="one">%d item has expired!</item>
+        <item quantity="other">%d items have expired!</item>
+    </plurals>
     <string name="notif_title_expired">Items have expired</string>
     <string name="notif_plus_more">+%d more</string>
     <string name="notif_snooze">Later</string>


### PR DESCRIPTION
Just a small beautification.
Add singular forms to avoid texts like "1 items have expired". Change de, es, fr, it, ja and pl translations accordingly. Change and complete cs translation accordingly. Change incomplete translations for el and tr (to the best of my knowledge, as I don't know these languages).
![out](https://user-images.githubusercontent.com/19879328/50377312-67fc9180-061b-11e9-81e9-c3adee4afd51.png)
