### PR TITLE
Get media types for lent items in SISIS api

### DIFF
--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountFragment.java
@@ -1191,11 +1191,13 @@ public class AccountFragment extends Fragment implements
         displayAge();
 
         boolean hideCovers = true;
-        for (LentItem item : result.getLent()) {
-            if (item.getMediaType() != null || item.getCover() != null) hideCovers = false;
-        }
-        for (ReservedItem item : result.getReservations()) {
-            if (item.getMediaType() != null || item.getCover() != null) hideCovers = false;
+        if( sp.getBoolean( "show_type_lent_items" , true) ){
+            for (LentItem item : result.getLent()) {
+                if (item.getMediaType() != null || item.getCover() != null) hideCovers = false;
+            }
+            for (ReservedItem item : result.getReservations()) {
+                if (item.getMediaType() != null || item.getCover() != null) hideCovers = false;
+            }
         }
         lentAdapter.setCoversHidden(hideCovers);
         resAdapter.setCoversHidden(hideCovers);

--- a/opacclient/opacapp/src/main/res/values-de/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-de/strings.xml
@@ -333,4 +333,7 @@
     <string name="load_covers_mobile_data">Buchcover über mobiles Netzwerk laden</string>
     <string name="load_covers_mobile_data_on">Buchcover werden geladen und angezeigt, wenn verfügbar</string>
     <string name="load_covers_mobile_data_off">Buchcover werden nur über WLAN geladen</string>
+    <string name="show_type_lent_items">Medienart/Buchcover in Ausleihliste zeigen</string>
+    <string name="show_type_lent_items_on">Medienart/Buchcover werden angezeigt</string>
+    <string name="show_type_lent_items_off">Medienart/Buchcover werden nicht angezeigt</string>
 </resources>

--- a/opacclient/opacapp/src/main/res/values-fr/strings.xml
+++ b/opacclient/opacapp/src/main/res/values-fr/strings.xml
@@ -314,4 +314,7 @@ les frais de votre bibliothèque.</string>
     <string name="intro_title_2">Plus de 1000 bibliothèques</string>
     <string name="intro_description_2">Cette application prend en charge plus de 1000 bibliothèques partout dans le monde. Sélectionnez la vôtre ou suggérez-la si elle n\'est pas encore sur la liste!</string>
     <string name="no_title">(aucun titre)</string>
+    <string name="show_type_lent_items">Afficher types d\'articles/images de couverture dans la liste des prêts en cours</string>
+    <string name="show_type_lent_items_on">Les types d\'articles/images de couverture sont affichées</string>
+    <string name="show_type_lent_items_off">Les types d\'articles/images de couverture ne sont pas affichées</string>
 </resources>

--- a/opacclient/opacapp/src/main/res/values/strings.xml
+++ b/opacclient/opacapp/src/main/res/values/strings.xml
@@ -332,4 +332,7 @@
     <string name="load_covers_mobile_data">Load covers while on mobile data</string>
     <string name="load_covers_mobile_data_on">Cover images will be loaded and displayed if available</string>
     <string name="load_covers_mobile_data_off">Cover images will only be loaded on WiFi</string>
+    <string name="show_type_lent_items">Show item type/cover in lent items list</string>
+    <string name="show_type_lent_items_on">Item type symbols/book covers are shown</string>
+    <string name="show_type_lent_items_off">Item type symbols/book covers are not shown</string>
 </resources>

--- a/opacclient/opacapp/src/main/res/xml/settings.xml
+++ b/opacclient/opacapp/src/main/res/xml/settings.xml
@@ -28,6 +28,14 @@
             android:title="@string/load_covers_mobile_data"
             android:summaryOn="@string/load_covers_mobile_data_on"
             android:summaryOff="@string/load_covers_mobile_data_off"/>
+        <CheckBoxPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="true"
+            android:key="show_type_lent_items"
+            android:summaryOff="@string/show_type_lent_items_off"
+            android:summaryOn="@string/show_type_lent_items_on"
+            android:title="@string/show_type_lent_items"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/notifications">
         <CheckBoxPreference


### PR DESCRIPTION
I missed the media type information in the lent items details because sometimes this is good to have, especially if you have lent different media types on a certain subject with more or less the same titles. Having fetched the media types, they're now available not only in the details view, but also show up in the lent items and reservations lists where they take up quite some space (especially on smaller displays). That's why I also added an option to show or hide the media type icons in the lent items and reservations lists (default is 'show'). There are a lot of libraries using SISIS in Germany and I wasn't sure if all users would find it nice to suddenly see the media type items in the list.
Getting the media types for lent items turned out to be very similar to getting them for search results, so I just reused the existing code by putting it into a function. My understanding of the api doc was that the `format` field is just a fallback option if `mediatype` can't be determined, so I only populate this field if no mediatype can be derived.  The new `MediaTypeOrFormat` inner class is only needed to let `getMediaTypeOrFormat` return two values of different types.