### PR TITLE
Shrink icon size in search results to 40 dp

### DIFF
--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/ResultsAdapter.java
@@ -51,10 +51,12 @@ import de.geeksfactory.opacclient.utils.BitmapUtils;
 
 public class ResultsAdapter extends ArrayAdapter<SearchResult> {
     private List<SearchResult> objects;
+    final int padding8dp;
 
     public ResultsAdapter(Context context, List<SearchResult> objects, OpacApi api) {
         super(context, R.layout.listitem_searchresult, objects);
         this.objects = objects;
+        this.padding8dp = (int)(8 * context.getResources().getDisplayMetrics().density + 0.5f);
     }
 
     @DrawableRes
@@ -162,6 +164,7 @@ public class ResultsAdapter extends ArrayAdapter<SearchResult> {
         if (item.getCoverBitmap() != null) {
             ivType.setImageBitmap(BitmapUtils.bitmapFromBytes(item.getCoverBitmap()));
             ivType.setVisibility(View.VISIBLE);
+            ivType.setPadding(0, 0, 0, 0);
         } else if ((pds.isLoadCoversOnDataPreferenceSet()
                 || !ConnectivityManagerCompat.isActiveNetworkMetered(connMgr))
                 && item.getCover() != null) {
@@ -169,9 +172,11 @@ public class ResultsAdapter extends ArrayAdapter<SearchResult> {
             lct.execute();
             ivType.setImageResource(R.drawable.ic_loading);
             ivType.setVisibility(View.VISIBLE);
+            ivType.setPadding(0, 0, 0, 0);
         } else if (item.getType() != null && item.getType() != MediaType.NONE) {
             ivType.setImageResource(getResourceByMediaType(item.getType()));
             ivType.setVisibility(View.VISIBLE);
+            ivType.setPadding(padding8dp, padding8dp, padding8dp, padding8dp);
         } else {
             ivType.setVisibility(View.INVISIBLE);
         }


### PR DESCRIPTION
This ensures **consistency in display between lent items list and search results list**. In the former (listitem_account_item.xml), there are individual image views for cover images and icons of size 56 and 40 dp, respectively, which are shown/hidden as needed. In the search results list, both covers and icons are displayed using the same 56 dp image view, which results in disproportionately big icons as compared to cover images. This is especially striking when book icons (landscape format) are mixed with cover images (usually portrait format).
Instead of introducing separate image views for covers and icons as in the lent items list, we just set a padding of 8 dp in case of icons being displayed in the ivType image view to shrink them to 40 dp. As the conversion from dp to px is a relatively expensive operation and needs a context, the calculated px value is cached.

|OLD | NEW |
|---|---|
|![_icon56](https://user-images.githubusercontent.com/19879328/50858589-1d0ba980-1391-11e9-9463-b7bd06b7a7b1.png)  | ![_icon40](https://user-images.githubusercontent.com/19879328/50858642-40ceef80-1391-11e9-9136-ee6b6fd2f828.png) |

(Sorry for being a bit pedantic about the views, but as we say in German _auch das Auge ißt mit_)