### PR TITLE
Use Google Play Services Security provider

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ lint:
     script:
         - cd opacclient
         - sed -i "s/.*versionName .*/        versionName \"git-${CI_BUILD_REF}\"/g" opacapp/build.gradle
-        - GRADLE_USER_HOME=/cache ANDROID_HOME=/android-sdk-linux ./gradlew lint test assembleDebug
+        - GRADLE_USER_HOME=/cache ANDROID_HOME=/android-sdk-linux ./gradlew lint test assembleGooglePlayServicesDebug
     except:
         - android-studio-library
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ android:
         - platform-tools
 script:
     - cd opacclient
-    - ./gradlew lintDebug test jacocoRootReport coveralls
+    - ./gradlew lintGooglePlayServicesDebug test jacocoRootReport coveralls
     - cat opacapp/build/reports/lint-results-debug.xml
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
 script:
     - cd opacclient
     - ./gradlew lintGooglePlayServicesDebug test jacocoRootReport coveralls
-    - cat opacapp/build/reports/lint-results-debug.xml
+    - cat opacapp/build/reports/lint-results-googlePlayServicesDebug.xml
 cache:
     directories:
         - $HOME/.gradle

--- a/opacclient/build.gradle
+++ b/opacclient/build.gradle
@@ -29,11 +29,11 @@ jacoco {
 
 task jacocoRootReport(type: JacocoReport) {
     dependsOn = [":libopac:jacocoTestReport", ":opacapp:jacocoTestReport"]
-    executionData files(["libopac/build/jacoco/test.exec", "opacapp/build/jacoco/testDebugUnitTest.exec"])
+    executionData files(["libopac/build/jacoco/test.exec", "opacapp/build/jacoco/testGooglePlayServicesDebugUnitTest.exec"])
     sourceDirectories = files(["opacapp/src/main/java", "libopac/src/main/java"])
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
-    def debugTree = fileTree(dir: "opacapp/build/intermediates/classes/debug", excludes: fileFilter)
+    def debugTree = fileTree(dir: "opacapp/build/intermediates/classes/googlePlayServicesDebug", excludes: fileFilter)
     def libopacDebugTree = fileTree(dir: "libopac/build/classes/java/main")
     classDirectories = files([debugTree, libopacDebugTree])
     jacocoClasspath = configurations.jacocoAnt

--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -127,7 +127,7 @@ jacoco {
     toolVersion = "0.7.4.201502262128"
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
+task jacocoTestReport(type: JacocoReport, dependsOn: 'testGooglePlayServicesDebugUnitTest') {
 
     reports {
         xml.enabled = true
@@ -137,12 +137,12 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
     jacocoClasspath = configurations['jacocoAnt']
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
-    def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/debug", excludes: fileFilter)
+    def debugTree = fileTree(dir: "${buildDir}/intermediates/classes/googlePlayServicesDebug", excludes: fileFilter)
     def mainSrc = "${project.projectDir}/src/main/java"
 
     sourceDirectories = files([mainSrc])
     classDirectories = files([debugTree])
-    executionData = files("${buildDir}/jacoco/testDebugUnitTest.exec")
+    executionData = files("${buildDir}/jacoco/testGooglePlayServicesDebugUnitTest.exec")
 }
 
 task downloadJson(type: JsonFilesTask)

--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -44,6 +44,17 @@ android {
             versionNameSuffix "-debug"
         }
     }
+
+    flavorDimensions "dependencies"
+    productFlavors {
+        googlePlayServices {
+            dimension "dependencies"
+        }
+        foss {
+            dimension "dependencies"
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -106,6 +117,7 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:okhttp:3.12.1'
     testImplementation 'com.squareup.retrofit2:retrofit-mock:2.3.0'
     testImplementation 'commons-io:commons-io:2.5'
+    googlePlayServicesImplementation 'com.google.android.gms:play-services-safetynet:15.0.1'
     // We don't want to rely on the CommonsWare Maven repo, so we include these libraries as JARs
     implementation files('libs/adapter-1.0.1.jar')
     implementation files('libs/endless-1.2.3.jar')

--- a/opacclient/opacapp/src/foss/java/de/geeksfactory/opacclient/utils/GooglePlayTools.java
+++ b/opacclient/opacapp/src/foss/java/de/geeksfactory/opacclient/utils/GooglePlayTools.java
@@ -1,0 +1,11 @@
+package de.geeksfactory.opacclient.utils;
+
+import android.content.Context;
+import android.content.Intent;
+
+public class GooglePlayTools {
+
+    public static void updateSecurityProvider(Context appContext) {
+        // do nothing
+    }
+}

--- a/opacclient/opacapp/src/googlePlayServices/java/de/geeksfactory/opacclient/utils/GooglePlayTools.java
+++ b/opacclient/opacapp/src/googlePlayServices/java/de/geeksfactory/opacclient/utils/GooglePlayTools.java
@@ -2,6 +2,7 @@ package de.geeksfactory.opacclient.utils;
 
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 
 import com.google.android.gms.security.ProviderInstaller;
 
@@ -11,12 +12,12 @@ public class GooglePlayTools {
         ProviderInstaller.installIfNeededAsync(appContext, new ProviderInstaller.ProviderInstallListener() {
             @Override
             public void onProviderInstalled() {
-
+                Log.d("OpacApp", "Google Play security provider installed.");
             }
 
             @Override
             public void onProviderInstallFailed(int i, Intent intent) {
-
+                Log.d("OpacApp", String.format("Google Play security provider failed to install. Error code: %d", i));
             }
         });
     }

--- a/opacclient/opacapp/src/googlePlayServices/java/de/geeksfactory/opacclient/utils/GooglePlayTools.java
+++ b/opacclient/opacapp/src/googlePlayServices/java/de/geeksfactory/opacclient/utils/GooglePlayTools.java
@@ -1,0 +1,23 @@
+package de.geeksfactory.opacclient.utils;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.google.android.gms.security.ProviderInstaller;
+
+public class GooglePlayTools {
+
+    public static void updateSecurityProvider(Context appContext) {
+        ProviderInstaller.installIfNeededAsync(appContext, new ProviderInstaller.ProviderInstallListener() {
+            @Override
+            public void onProviderInstalled() {
+
+            }
+
+            @Override
+            public void onProviderInstallFailed(int i, Intent intent) {
+
+            }
+        });
+    }
+}

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/OpacClient.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/OpacClient.java
@@ -74,6 +74,7 @@ import de.geeksfactory.opacclient.storage.PreferenceDataSource;
 import de.geeksfactory.opacclient.storage.StarContentProvider;
 import de.geeksfactory.opacclient.utils.DebugTools;
 import de.geeksfactory.opacclient.utils.ErrorReporter;
+import de.geeksfactory.opacclient.utils.GooglePlayTools;
 import de.geeksfactory.opacclient.utils.Utils;
 import de.geeksfactory.opacclient.webservice.LibraryConfigUpdateService;
 import de.geeksfactory.opacclient.webservice.UpdateHandler;
@@ -371,6 +372,9 @@ public class OpacClient extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        GooglePlayTools.updateSecurityProvider(getApplicationContext());
+
         sp = PreferenceManager.getDefaultSharedPreferences(this);
 
         if (!BuildConfig.DEBUG) {


### PR DESCRIPTION
so that we can use up-to-date TLS versions and cipher suites on older Android devices, provided that they have a recent version Google Play Services installed (otherwise, the app will ignore it and use the system default security provider - no error message is shown).

This introduces two build flavors ("foss" and "googlePlayServices") to the app, which means we need to update our scripts to generate release builds for Google Play (@raphaelm ?) as well as F-Droid.