### PR TITLE
Fix: No signature of method: ...cleanDirectory()

### DIFF
--- a/opacclient/buildSrc/src/main/groovy/de/geeksfactory/opacclient/gradle/JsonFilesTask.groovy
+++ b/opacclient/buildSrc/src/main/groovy/de/geeksfactory/opacclient/gradle/JsonFilesTask.groovy
@@ -26,7 +26,8 @@ class JsonFilesTask extends DefaultTask {
         String response = conn.inputStream.getText("UTF-8")
         JSONArray data = new JSONArray(response)
         GFileUtils.mkdirs(new File(bibsDir))
-        GFileUtils.cleanDirectory(new File(bibsDir))
+        GFileUtils.deleteDirectory(new File(bibsDir))
+        GFileUtils.mkdirs(new File(bibsDir))
         for (int i = 0; i < data.length(); i++) {
             JSONObject library = data.get(i)
             String id = library.getString("_id")


### PR DESCRIPTION
Everytime I run `./gradlew downloadJson` I get the following error:
No signature of method: static org.gradle.util.GFileUtils.cleanDirectory()