### PR TITLE
Fix array index range of JSONArray extension functions

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/utils/KotlinUtils.kt
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/utils/KotlinUtils.kt
@@ -27,7 +27,7 @@ val TextNode.text: String
 
 // JSONArray extension functions
 inline fun <reified T, R> JSONArray.map(transform: (T) -> R): List<R> =
-        (0..length()).map { i -> transform(get(i) as T) }
+        (0.until(length())).map { i -> transform(get(i) as T) }
 
 inline fun <reified T> JSONArray.forEach(function: (T) -> Unit) =
-        (0..length()).forEach { i -> function(get(i) as T) }
+        (0.until(length())).forEach { i -> function(get(i) as T) }


### PR DESCRIPTION
The rangeTo operator ".." includes the end element which leads to an array index
out of range error. The "until" function does not include the end element.
see https://kotlinlang.org/docs/reference/ranges.html