### PR TITLE
SISIS: fix regex for cover URL for Dresden Städtische Bibliotheken

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SISIS.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SISIS.java
@@ -196,6 +196,8 @@ public class SISIS extends OkHttpBaseApi implements OpacApi {
     protected long logged_in;
     protected Account logged_in_as;
     protected static final String ENCODING = "UTF-8";
+    protected static final Pattern coverPattern = Pattern.compile(
+            "\\$\\.ajax\\(\\{\\s*url:\\s*'(?:/webOPACClient/)?(jsp/result/cover.jsp\\?[^']+)'");
 
     protected String getDefaultEncoding() {
         return ENCODING;
@@ -472,9 +474,7 @@ public class SISIS extends OkHttpBaseApi implements OpacApi {
 
             // covers loaded with AJAX (seen in Wuppertal)
             if (tr.children().size() > 3 && tr.child(3).html().contains("jsp/result/cover.jsp")) {
-                Pattern pattern = Pattern.compile(
-                        "\\$\\.ajax\\(\\{\\s*url:\\s*'(jsp/result/cover.jsp\\?[^']+)',");
-                Matcher matcher = pattern.matcher(tr.child(3).html());
+                Matcher matcher = coverPattern.matcher(tr.child(3).html());
                 if (matcher.find()) {
                     String url = opac_url + "/" + matcher.group(1);
                     futures.add(CompletableFuture.runAsync(() -> {
@@ -744,8 +744,6 @@ public class SISIS extends OkHttpBaseApi implements OpacApi {
                 ENCODING);
 
         String coverJs = null;
-        Pattern coverPattern = Pattern.compile("\\$\\.ajax\\(\\{[\\n\\s]*url: '(jsp/result/cover" +
-                ".jsp\\?[^']+')");
         Matcher coverMatcher = coverPattern.matcher(html);
         if (coverMatcher.find()) {
             coverJs = httpGet(opac_url + "/" + coverMatcher.group(1), ENCODING);

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SISISTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SISISTest.java
@@ -11,6 +11,7 @@ import de.geeksfactory.opacclient.objects.Account;
 import de.geeksfactory.opacclient.objects.AccountData;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -104,5 +105,51 @@ public class SISISTest extends BaseHtmlTest {
         assertEquals(
                 "http://webopac.wuppertal.de/showMVBCover.do?token=2aa75c57-40a7-4c99-b501-d49b39ada7a9",
                 url);
+    }
+
+    @Test
+    public void testGetAjaxCoverUrlRelPath() {
+        // as found at Stadt- und Regionalbibliothek Erfurt
+        String html = "    <!--\n" +
+                "      $.ajax({\n" +
+                "        url: 'jsp/result/cover.jsp?localImg=&isbns=%5B978-3-8317-3282-1%5D&asins=%5B%5D&size=medium&pos=-1_1',\n" +
+                "        dataType: 'script'\n" +
+                "      });\n" +
+                "    //-->";
+        String actual = sisis.getAjaxCoverUrl(html);
+        assertEquals("https://opac.erfurt.de/webOPACClient/jsp/result/cover.jsp?localImg=&isbns=%5B978-3-8317-3282-1%5D&asins=%5B%5D&size=medium&pos=-1_1", actual);
+    }
+
+    @Test
+    public void testGetAjaxCoverUrlAbsPath() {
+        // as found at Städtischen Bibliotheken Dresden
+        String html = "    <!--\n" +
+                "      $.ajax({\n" +
+                "        url: '/webOPACClient/jsp/result/cover.jsp?localImg=&isbns=%5B978-3-8317-3282-1%5D&asins=%5B%5D&size=medium&pos=cover_-1_1',\n" +
+                "        dataType: 'script'\n" +
+                "      });\n" +
+                "    //-->";
+        String actual = sisis.getAjaxCoverUrl(html);
+        assertEquals("https://opac.erfurt.de/webOPACClient/jsp/result/cover.jsp?localImg=&isbns=%5B978-3-8317-3282-1%5D&asins=%5B%5D&size=medium&pos=cover_-1_1", actual);
+    }
+
+    @Test
+    public void testGetAjaxCoverUrlNoPath() {
+        // as found at Stadtbibliothek Riesa (cover images come from amazon)
+        String actual = sisis.getAjaxCoverUrl("");
+        assertNull(actual);
+    }
+
+    @Test
+    public void testGetAjaxCoverUrlBadPath() {
+        // made up example of url with unencoded space
+        String html = "    <!--\n" +
+                "      $.ajax({\n" +
+                "        url: 'jsp/result/cover.jsp?localImg=&isbns= %5B978-3-8317-3282-1%5D&asins=%5B%5D&size=medium&pos=-1_1',\n" +
+                "        dataType: 'script'\n" +
+                "      });\n" +
+                "    //-->";
+        String actual = sisis.getAjaxCoverUrl(html);
+        assertNull(actual);
     }
 }


### PR DESCRIPTION
In Dresden, they changed the URL in the AJAX section: it now starts with "/webOPACClient/", which is also part of the opac_url.
OLD: `"jsp/result..." ` (used for instance in Erfurt)
NEW: `"/webOPACClient/jsp/result..."` (used in Dresden)

So we retrieve just the part starting with `"jsp/result..."`

Eliminate duplicate definition of the regex in `parse_search` and `loadDetail.`