### PR TITLE
Improve title readability against light background

### DIFF
--- a/opacclient/opacapp/src/main/res/values/styles_opacapp.xml
+++ b/opacclient/opacapp/src/main/res/values/styles_opacapp.xml
@@ -71,6 +71,8 @@
 
     <style name="TextAppearance.Opacapp.ExpandedMediaTitle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
         <item name="android:textSize">26sp</item>
+        <item name="android:shadowRadius">15</item>
+        <item name="android:shadowColor">@android:color/black</item>
     </style>
 
     <style name="ThemeOverlay.Opacapp.ActionBar"


### PR DESCRIPTION
Especially for wide cover images (CDs etc.) and/or long title (3 lines high), the title in white font is barely or not at all discernible if the cover image is predominantly white or heavily patterned. A black font shadow
greatly improves readability in such cases.

<img src="https://user-images.githubusercontent.com/19879328/97807985-323b8180-1c64-11eb-8ae3-a802fb292043.png" alt="old - plain text" width="300">  <img src="https://user-images.githubusercontent.com/19879328/97808098-0e2c7000-1c65-11eb-94aa-e86f44d64d28.png" alt="new - with shadow" width="300">
left: current appearance &nbsp;&nbsp; &nbsp;  right: improved with shadow

An alternative solution would be to programmatically increase the hight of the lower gradient view (`gradient_bottom`) depending on the number of text lines but in my opinion the shadow is much easier to implement and looks just fine.

I couldn't figure out how to change the shadow color to match the background color. So we also have a dark shadow when there's no cover image, but I think it looks OK (below left). I noticed that when you start to slide up the toolbar the shadow of the whole truncated string of the original (single line) collapsing toolbar is being displayed (below right). This seems to be a bug in the implementation of the multi-line collapsing toolbar but it'is far beyond my knowledge of android to find the exact place where the bug happens, let alone to fix it.


<img src="https://user-images.githubusercontent.com/19879328/97808515-a0ce0e80-1c67-11eb-8cd8-b0b037aa32a7.png" alt="new - no cover" width="300">  <img src="https://user-images.githubusercontent.com/19879328/97808767-02db4380-1c69-11eb-94b8-ddef37821190.png" alt="new - artifact" width="300"> 
left: shadow against uniform background &nbsp;&nbsp; &nbsp;  right: shadow artifact  

(sorry for the trailing line feed change, it was automatically added by Android Studio and i didn't notice it at first)


