### PR TITLE
SLUB: Fix titles in account view (loans and reservations)

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
@@ -434,7 +434,7 @@ open class SLUB : OkHttpBaseApi() {
             for (type in types) {
                 items?.optJSONArray(type)?.forEach<JSONObject> {
                     reservationsList.add(ReservedItem().apply {
-                        title = it.optString("about")
+                        title = it.optString("about").replace("¬", "")
                         author = it.optJSONArray("X_author")?.optString(0)
                         id = "bc/${it.optString("label")}"
                         format = it.optString("X_medientyp")
@@ -460,7 +460,7 @@ open class SLUB : OkHttpBaseApi() {
             }
             items?.optJSONArray("ill")?.forEach<JSONObject> {
                 reservationsList.add(ReservedItem().apply {
-                    title = it.optString("Titel")
+                    title = it.optString("Titel").replace("¬", "")
                     author = it.optString("Autor")
                     //id = it.optString("Fernleih_ID") --> this id is of no use whatsoever
                     it.optString("Medientyp")?.run {
@@ -481,7 +481,7 @@ open class SLUB : OkHttpBaseApi() {
             lent = json.optJSONObject("items")?.optJSONArray("loan")    // TODO: plus permanent loans? (need example)
                     ?.map<JSONObject, LentItem> {
                         LentItem().apply {
-                            title = it.optString("about")
+                            title = it.optString("about").replace("¬", "")
                             author = it.optJSONArray("X_author")?.optString(0)
                             setDeadline(it.optString("X_date_due"))
                             format = it.optString("X_medientyp")

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
@@ -94,7 +94,7 @@ class SLUBAccountTest : BaseHtmlTest() {
         val json = JSONObject(readResource("/slub/account/account.json"))
         val fmt = DateTimeFormat.shortDate()
         val lentitem1 = LentItem().apply {
-            title = "¬Der¬ neue Kosmos-Baumführer"
+            title = "Der neue Kosmos-Baumführer"
             author = "Bachofer, Mark"
             setDeadline("2019-06-03")
             format = "B"

--- a/opacclient/libopac/src/test/resources/slub/account/account.json
+++ b/opacclient/libopac/src/test/resources/slub/account/account.json
@@ -140,7 +140,7 @@
     "request_ready": [
       {
         "status": 1,
-        "about": "Englische Synonyme als Fehlerquellen",
+        "about": "¬Englische Synonyme als Fehlerquellen",
         "label": "20550495",
         "starttime": "2019-05-04T06:35:39Z",
         "X_status_desc": "requested",


### PR DESCRIPTION
The title in the json obtained from the API may contain ¬ signs which are not
shown in the web catalog. These signs are removed for better readability.

**Current display in opacapp:**
![vorher](https://user-images.githubusercontent.com/19879328/100241547-19a54b00-2f34-11eb-820a-3245997efd53.png)  

**Current display on library web page:**
![web](https://user-images.githubusercontent.com/19879328/100241597-2629a380-2f34-11eb-9b1c-035f1d84d2f8.png)

**Fixed display in opacapp:**
![grafik](https://user-images.githubusercontent.com/19879328/100241718-4b1e1680-2f34-11eb-9cae-c8b97d6f64da.png)

(we leave ¬ signs in the contributor field as they are used, when followed by a bracket [, to cut off the contributor's role in the list view, see f16534969939)


