### PR TITLE
SLUB: add some more media types

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
@@ -65,7 +65,10 @@ open class SLUB : OkHttpBaseApi() {
             "Electronic Resource (Data Carrier)" to SearchResult.MediaType.EAUDIO,
             "Image" to SearchResult.MediaType.ART,
             "Microform" to SearchResult.MediaType.MICROFORM,
-            "Visual Media" to SearchResult.MediaType.ART
+            "Visual Media" to SearchResult.MediaType.ART,
+            "Electronic Resource" to SearchResult.MediaType.CD_SOFTWARE, // typically CD-ROM or DVD-ROM
+            "Physical Object" to SearchResult.MediaType.DEVICE,
+            "Norm" to SearchResult.MediaType.EDOC
     )
 
     private val fieldCaptions = mapOf(


### PR DESCRIPTION
There is no specific media type for `"Norm"` (norms or standards). As these are mostly electronic resources (at least the current norms) I mapped them to the media type `EDOC`. Or do we need a new, more specific mediatype for it?