### PR TITLE
SLUB: resolve html escapes in sublocation

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
@@ -196,7 +196,7 @@ open class SLUB : OkHttpBaseApi() {
                     Copy().apply {
                         barcode = it.getString("barcode")
                         branch = it.getString("location")
-                        department = it.getString("sublocation") // or location = ...
+                        department = Parser.unescapeEntities(it.getString("sublocation"), false)
                         shelfmark = it.getString("shelfmark")
                         status = Jsoup.parse(it.getString("statusphrase")).text()
                         it.getString("duedate").run {

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
@@ -238,7 +238,7 @@ class SLUBSearchTest : BaseHtmlTest() {
             id = "id/0-1182402208"
             copies = arrayListOf(Copy().apply {
                 barcode = "31541466"
-                department = "Freihand"
+                department = "Ausgabe über Ausleihtheke"
                 branch = "Bereichsbibliothek DrePunct"
                 status = "Ausleihbar"
                 shelfmark = "ST 233 H939"

--- a/opacclient/libopac/src/test/resources/slub/search/simple-item.json
+++ b/opacclient/libopac/src/test/resources/slub/search/simple-item.json
@@ -59,7 +59,7 @@
       "barcode": "31541466",
       "location": "Bereichsbibliothek DrePunct",
       "location_code": "zell9",
-      "sublocation": "Freihand",
+      "sublocation": "Ausgabe &uuml;ber Ausleihtheke",
       "shelfmark": "ST 233 H939",
       "mediatype": "B",
       "3d": "ST 233 H939",


### PR DESCRIPTION
Sublocation names (stored in the `department` field) can contain HTML escape entities, e.g. _"Ausgabe \&uuml;ber Ausleihtheke"_ or _"Au\&szlig;enmagazin"_. These are now resolved regular characters.