### PR TITLE
Show status text for copies in color

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
@@ -189,6 +189,7 @@ open class SLUB : OkHttpBaseApi() {
     }
 
     internal fun parseResultById(json: JSONObject): DetailedItem {
+        val colorcodes = mapOf("1" to "#00CC00", "2" to "#FF8900", "3" to "#CC0000")
         val dateFormat = DateTimeFormat.forPattern("dd.MM.yyyy")
         var hasReservableCopies = false
         fun getCopies(copiesArray: JSONArray, df: DateTimeFormatter): List<Copy> =
@@ -198,7 +199,8 @@ open class SLUB : OkHttpBaseApi() {
                         branch = it.getString("location")
                         department = it.getString("sublocation") // or location = ...
                         shelfmark = it.getString("shelfmark")
-                        status = Jsoup.parse(it.getString("statusphrase")).text()
+                        val color = colorcodes.getOrElse(it.getString("colorcode")) { "#000000" }
+                        status = "<p style=\"color:$color\";>${it.getString("statusphrase")}</p>"
                         it.getString("duedate").run {
                             if (isNotEmpty()) {
                                 returnDate = df.parseLocalDate(this)
@@ -311,7 +313,7 @@ open class SLUB : OkHttpBaseApi() {
                 else -> {
                     val options = reservableCopies.map { copy ->
                         mapOf("key" to copy.resInfo,
-                                "value" to "${copy.branch}: ${copy.status}")
+                                "value" to "${copy.branch}: ${Jsoup.parse(copy.status).text()}")
                     }
                     return OpacApi.ReservationResult(OpacApi.MultiStepResult.Status.SELECTION_NEEDED,
                             stringProvider.getString(StringProvider.ITEM_COPY)).apply {

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
@@ -240,7 +240,7 @@ class SLUBSearchTest : BaseHtmlTest() {
                 barcode = "31541466"
                 department = "Freihand"
                 branch = "Bereichsbibliothek DrePunct"
-                status = "Ausleihbar"
+                status = "<p style=\"color:#00CC00\";>Ausleihbar</p>"
                 shelfmark = "ST 233 H939"
             })
             collectionId = "id/0-1183957874"
@@ -260,7 +260,7 @@ class SLUBSearchTest : BaseHtmlTest() {
             barcode = "10418078"
             department = "Magazin Zeitschriften"
             branch = "Zentralbibliothek"
-            status = "Bestellen zur Benutzung im Haus, kein Versand per Fernleihe, nur Kopienlieferung"
+            status = "<p style=\"color:#FF8900\";>Bestellen zur Benutzung im Haus, kein Versand per Fernleihe, nur Kopienlieferung</p>"
             shelfmark = "19 4 01339 0 0024 1 01"
             resInfo = "stackRequest\t10418078"
         }
@@ -268,7 +268,7 @@ class SLUBSearchTest : BaseHtmlTest() {
             barcode = "33364639"
             department = "Magazin Zeitschriften"
             branch = "Zentralbibliothek"
-            status = "Bestellen zur Benutzung im Haus, kein Versand per Fernleihe, nur Kopienlieferung"
+            status = "<p style=\"color:#FF8900\";>Bestellen zur Benutzung im Haus, kein Versand per Fernleihe, nur Kopienlieferung</p>"
             shelfmark = "19 4 01339 1 1969 1 01"
             resInfo = "stackRequest\t33364639"
         }
@@ -391,7 +391,7 @@ class SLUBSearchTest : BaseHtmlTest() {
                         barcode = "10059731"
                         department = "Freihand"
                         branch = "Zentralbibliothek"
-                        status = "Ausgeliehen, Vormerken möglich"
+                        status = "<p style=\"color:#CC0000\";>Ausgeliehen, Vormerken m&ouml;glich</p>"
                         shelfmark = "LK 24099 B644"
                         returnDate = LocalDate(2020, 2, 5)
                         resInfo = "reserve\t10059731"
@@ -401,14 +401,14 @@ class SLUBSearchTest : BaseHtmlTest() {
                         barcode = "30523028"
                         department = "Freihand"
                         branch = "ZwB Erziehungswissenschaften"
-                        status = "Benutzung nur im Haus, Versand per Fernleihe möglich"
+                        status = "<p style=\"color:#00CC00\";>Benutzung nur im Haus, Versand per Fernleihe m&ouml;glich</p>"
                         shelfmark = "NR 6400 B644 F9"
                     },
                     Copy().apply {
                         barcode = "20065307"
                         department = "Magazin"
                         branch = "Zentralbibliothek"
-                        status = "Ausleihbar, bitte bestellen"
+                        status = "<p style=\"color:#FF8900\";>Ausleihbar, bitte bestellen</p>"
                         shelfmark = "65.4.653.b"
                         resInfo = "stackRequest\t20065307"
                     }

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
@@ -2,6 +2,7 @@ package de.geeksfactory.opacclient.frontend;
 
 import android.content.Context;
 import android.text.Html;
+import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -52,6 +53,7 @@ public class CopiesAdapter extends RecyclerView.Adapter<CopiesAdapter.ViewHolder
     private void setTextOrHide(String text, TextView tv) {
         if (notEmpty(text)) {
             tv.setText(Html.fromHtml(text));
+            tv.setMovementMethod(LinkMovementMethod.getInstance());
             tv.setVisibility(View.VISIBLE);
         } else {
             tv.setVisibility(View.GONE);

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
@@ -1,6 +1,7 @@
 package de.geeksfactory.opacclient.frontend;
 
 import android.content.Context;
+import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -50,7 +51,7 @@ public class CopiesAdapter extends RecyclerView.Adapter<CopiesAdapter.ViewHolder
 
     private void setTextOrHide(String text, TextView tv) {
         if (notEmpty(text)) {
-            tv.setText(text);
+            tv.setText(Html.fromHtml(text));
             tv.setVisibility(View.VISIBLE);
         } else {
             tv.setVisibility(View.GONE);


### PR DESCRIPTION
This is to mimic the SLUB web catalog behavior (left web catalog, right app with this PR):
<img src="https://user-images.githubusercontent.com/19879328/101918170-59716100-3bc9-11eb-9323-fa89a6759e38.png" width="400">  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;    <img src="https://user-images.githubusercontent.com/19879328/101918390-99384880-3bc9-11eb-8005-47ae3d492e52.png" width="250">  

This also allows to click on links in the status text as in the web catalog (left old: no color, non-clickable, right new: color and clickable):
<img src="https://user-images.githubusercontent.com/19879328/101918939-48751f80-3bca-11eb-9778-cb5b06c6bf8c.gif" width="250">   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;   <img src="https://user-images.githubusercontent.com/19879328/101919045-6cd0fc00-3bca-11eb-8922-47e28ec89689.gif" width="250">


I used the same colors as for the status markers in the search result list view. The green could be a bit less bright to be better readable, like the green color in the web catalog on the left side. Would you want to change it or leave it as is?

