### PR TITLE
Prevent cleanUrl from adding equal sign to query parameters

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/BaseApi.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/BaseApi.java
@@ -485,7 +485,7 @@ public abstract class BaseApi implements OpacApi {
                                 "UTF-8")));
                     } else {
                         params.add(new BasicNameValuePair(URLDecoder.decode(
-                                kv[0], "UTF-8"), ""));
+                                kv[0], "UTF-8"), null));
                     }
                 }
                 url += URLEncodedUtils.format(params, "UTF-8");

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/ApacheBaseApiTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/ApacheBaseApiTest.java
@@ -8,15 +8,8 @@ import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 
 public class ApacheBaseApiTest {
-    @Test
-    public void cleanUrlShouldHandleMultipleEqualsSigns() throws Exception {
-        String url = "http://www.example.com/file?param1=value=1&param=value2";
-        assertEquals("http://www.example.com/file?param1=value%3D1&param=value2",
-                ApacheBaseApi.cleanUrl(url));
-    }
 
     @Test
     public void testBuildHttpGetParamsList() throws Exception {

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/BaseApiTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/BaseApiTest.java
@@ -1,0 +1,22 @@
+package de.geeksfactory.opacclient.apis;
+
+import org.junit.Test;
+
+import static de.geeksfactory.opacclient.apis.BaseApi.cleanUrl;
+import static org.junit.Assert.assertEquals;
+
+public class BaseApiTest {
+    @Test
+    public void cleanUrlShouldHandleMultipleEqualsSigns() {
+        String url = "http://www.example.com/file?param1=value=1&param=value2";
+        assertEquals("http://www.example.com/file?param1=value%3D1&param=value2",
+                cleanUrl(url));
+    }
+
+    @Test
+    public void cleanUrlShouldHandleKeyOnlyParameters() {
+        String url = "http://www.example.com/file?param1&param2=value2";
+        assertEquals("http://www.example.com/file?param1&param2=value2",
+                cleanUrl(url));
+    }
+}


### PR DESCRIPTION
According to RFE3986 the query component may be any form, not necessarily
in the form of key=value pairs. The existing implementation of cleanUrl
added an equal sign (=) to data not in the form of key=value pairs. This
lead to infinite redirects in a HEAD request in the SLUB API and is fixed
now to leave query data without an equal sign as is.

Move tests for cleanUrl from ApacheBaseApiTest to BaseApiTest as it's a
method of the BaseApi.

see also https://github.com/opacapp/opacclient/issues/595#issuecomment-787106036
