### PR TITLE
Make cleanUrl non-static so that APIs can overwrite it

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/BaseApi.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/BaseApi.java
@@ -464,7 +464,7 @@ public abstract class BaseApi implements OpacApi {
      * @param myURL the URL to clean
      * @return cleaned URL
      */
-    public static String cleanUrl(String myURL) {
+    public String cleanUrl(String myURL) {
         String[] parts = myURL.split("\\?");
         String url = parts[0];
         try {

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/ApacheBaseApiTest.java
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/ApacheBaseApiTest.java
@@ -3,6 +3,7 @@ package de.geeksfactory.opacclient.apis;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 
@@ -12,10 +13,11 @@ import static org.junit.Assert.assertEquals;
 
 public class ApacheBaseApiTest {
     @Test
-    public void cleanUrlShouldHandleMultipleEqualsSigns() throws Exception {
+    public void cleanUrlShouldHandleMultipleEqualsSigns() {
+        BaseApi baseApi = Mockito.mock(BaseApi.class, Mockito.CALLS_REAL_METHODS);
         String url = "http://www.example.com/file?param1=value=1&param=value2";
         assertEquals("http://www.example.com/file?param1=value%3D1&param=value2",
-                ApacheBaseApi.cleanUrl(url));
+                baseApi.cleanUrl(url));
     }
 
     @Test


### PR DESCRIPTION
cleanUrl replaces missing values in key-value-pairs with an empty string so that
?param&... becomes ?param=&... . This may lead to problems in some cases (e.g.
at SLUBApi when resolving libero references in getDetailById). Even it we'd
replace the "" by null in the else branch of the current implementation, a
trailing = will still be be added by URLEncodedUtils.format, as Android uses
httpclient-android version 4.3.5.1 which has a bug to add a trailing = sign
to key-only parameters by replacing missing parameters with empty strings the
same way clearUrl does (versions 4.5 and newer work correctly but can't be
used by Android, see also https://hc.apache.org/httpcomponents-client-4.5.x/android.html.

To avoid this we make cleanUrl non-static so that APIs can overwrite
it with their own version as needed.

This is a follow-up PR to #612 as discussed in https://github.com/opacapp/opacclient/pull/612#issuecomment-787866610.