### PR TITLE
 Provide status code for copies and show colored status markers

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
@@ -189,6 +189,7 @@ open class SLUB : OkHttpBaseApi() {
     }
 
     internal fun parseResultById(json: JSONObject): DetailedItem {
+        val colorcodes = mapOf("1" to SearchResult.Status.GREEN, "2" to SearchResult.Status.YELLOW, "3" to SearchResult.Status.RED)
         val dateFormat = DateTimeFormat.forPattern("dd.MM.yyyy")
         var hasReservableCopies = false
         fun getCopies(copiesArray: JSONArray, df: DateTimeFormatter): List<Copy> =
@@ -199,6 +200,7 @@ open class SLUB : OkHttpBaseApi() {
                         department = Parser.unescapeEntities(it.getString("sublocation"), false)
                         shelfmark = it.getString("shelfmark")
                         status = Jsoup.parse(it.getString("statusphrase")).text()
+                        statusCode = colorcodes.getOrElse(it.getString("colorcode")) { SearchResult.Status.UNKNOWN }
                         it.getString("duedate").run {
                             if (isNotEmpty()) {
                                 returnDate = df.parseLocalDate(this)

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/objects/Copy.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/objects/Copy.java
@@ -32,6 +32,7 @@ public class Copy {
     private String branch;
     private String issue;
     private String status;
+    private SearchResult.Status statusCode;
     private LocalDate returnDate;
     private String reservations;
     private String shelfmark;
@@ -121,6 +122,20 @@ public class Copy {
      */
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    /**
+     * @return Current status code of a copy or <code>null</code> if not set.
+     */
+    public SearchResult.Status getStatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * @param statusCode Current status code of a copy.
+     */
+    public void setStatusCode(SearchResult.Status statusCode) {
+        this.statusCode = statusCode;
     }
 
     /**
@@ -322,6 +337,7 @@ public class Copy {
                 || getDepartment() != null
                 || getBranch() != null
                 || getStatus() != null
+                || getStatusCode() != null
                 || getReturnDate() != null
                 || getReservations() != null
                 || getShelfmark() != null
@@ -338,6 +354,7 @@ public class Copy {
                 ", department='" + department + '\'' +
                 ", branch='" + branch + '\'' +
                 ", status='" + status + '\'' +
+                ", statusCode='" + statusCode + '\'' +
                 ", returnDate=" + returnDate +
                 ", reservations='" + reservations + '\'' +
                 ", shelfmark='" + shelfmark + '\'' +

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
@@ -241,6 +241,7 @@ class SLUBSearchTest : BaseHtmlTest() {
                 department = "Ausgabe über Ausleihtheke"
                 branch = "Bereichsbibliothek DrePunct"
                 status = "Ausleihbar"
+                statusCode = SearchResult.Status.GREEN
                 shelfmark = "ST 233 H939"
             })
             collectionId = "id/0-1183957874"
@@ -261,6 +262,7 @@ class SLUBSearchTest : BaseHtmlTest() {
             department = "Magazin Zeitschriften"
             branch = "Zentralbibliothek"
             status = "Bestellen zur Benutzung im Haus, kein Versand per Fernleihe, nur Kopienlieferung"
+            statusCode = SearchResult.Status.YELLOW
             shelfmark = "19 4 01339 0 0024 1 01"
             resInfo = "stackRequest\t10418078"
         }
@@ -269,6 +271,7 @@ class SLUBSearchTest : BaseHtmlTest() {
             department = "Magazin Zeitschriften"
             branch = "Zentralbibliothek"
             status = "Bestellen zur Benutzung im Haus, kein Versand per Fernleihe, nur Kopienlieferung"
+            statusCode = SearchResult.Status.YELLOW
             shelfmark = "19 4 01339 1 1969 1 01"
             resInfo = "stackRequest\t33364639"
         }
@@ -392,6 +395,7 @@ class SLUBSearchTest : BaseHtmlTest() {
                         department = "Freihand"
                         branch = "Zentralbibliothek"
                         status = "Ausgeliehen, Vormerken möglich"
+                        statusCode = SearchResult.Status.RED
                         shelfmark = "LK 24099 B644"
                         returnDate = LocalDate(2020, 2, 5)
                         resInfo = "reserve\t10059731"
@@ -402,6 +406,7 @@ class SLUBSearchTest : BaseHtmlTest() {
                         department = "Freihand"
                         branch = "ZwB Erziehungswissenschaften"
                         status = "Benutzung nur im Haus, Versand per Fernleihe möglich"
+                        statusCode = SearchResult.Status.GREEN
                         shelfmark = "NR 6400 B644 F9"
                     },
                     Copy().apply {
@@ -409,6 +414,7 @@ class SLUBSearchTest : BaseHtmlTest() {
                         department = "Magazin"
                         branch = "Zentralbibliothek"
                         status = "Ausleihbar, bitte bestellen"
+                        statusCode = SearchResult.Status.YELLOW
                         shelfmark = "65.4.653.b"
                         resInfo = "stackRequest\t20065307"
                     }

--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'jacoco'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "de.geeksfactory.opacclient"
@@ -83,6 +83,7 @@ android {
 
     testOptions {
         unitTests.returnDefaultValues = true
+        unitTests.includeAndroidResources = true
     }
 
     buildFeatures {
@@ -140,11 +141,15 @@ dependencies {
     //debugImplementation 'com.squareup.leakcanary:leakcanary-android:x.y'
 
 // Testing
-    testImplementation 'org.mockito:mockito-core:3.3.3'
+    testImplementation 'org.mockito:mockito-core:3.8.0'
     testImplementation 'junit:junit:4.13'
     testImplementation 'com.squareup.okhttp3:okhttp:3.12.12'
     testImplementation 'com.squareup.retrofit2:retrofit-mock:2.6.4'
     testImplementation 'commons-io:commons-io:2.7'
+    testImplementation 'androidx.test:core:1.3.0'
+    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'org.mockito:mockito-inline:3.8.0'
 }
 
 jacoco {

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
@@ -13,6 +13,7 @@ import java.util.List;
 import androidx.recyclerview.widget.RecyclerView;
 import de.geeksfactory.opacclient.R;
 import de.geeksfactory.opacclient.objects.Copy;
+import de.geeksfactory.opacclient.objects.SearchResult;
 
 public class CopiesAdapter extends RecyclerView.Adapter<CopiesAdapter.ViewHolder> {
     private final List<Copy> copies;
@@ -45,6 +46,22 @@ public class CopiesAdapter extends RecyclerView.Adapter<CopiesAdapter.ViewHolder
             holder.tvReturndate.setVisibility(View.VISIBLE);
         } else {
             holder.tvReturndate.setVisibility(View.GONE);
+        }
+        SearchResult.Status statusCode = copy.getStatusCode();
+        if(statusCode != null){
+            switch (statusCode) {
+                case GREEN:
+                    holder.tvStatus.setCompoundDrawablesWithIntrinsicBounds(R.drawable.status_light_green_check, 0,0,0);
+                    break;
+                case RED:
+                    holder.tvStatus.setCompoundDrawablesWithIntrinsicBounds(R.drawable.status_light_red_cross, 0,0,0);
+                    break;
+                case YELLOW:
+                    holder.tvStatus.setCompoundDrawablesWithIntrinsicBounds(R.drawable.status_light_yellow_alert, 0,0,0);
+                    break;
+                default:
+                    holder.tvStatus.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_status_24dp, 0,0,0);
+            }
         }
     }
 

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
@@ -83,7 +83,7 @@ public class CopiesAdapter extends RecyclerView.Adapter<CopiesAdapter.ViewHolder
         return text != null && !text.isEmpty();
     }
 
-    public class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         public TextView tvBranch;
         public TextView tvDepartment;
         public TextView tvIssue;

--- a/opacclient/opacapp/src/test/java/de/geeksfactory/opacclient/frontend/CopiesAdapterTest.java
+++ b/opacclient/opacapp/src/test/java/de/geeksfactory/opacclient/frontend/CopiesAdapterTest.java
@@ -1,0 +1,146 @@
+package de.geeksfactory.opacclient.frontend;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.joda.time.LocalDate;
+import org.joda.time.format.DateTimeFormat;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+
+import de.geeksfactory.opacclient.R;
+import de.geeksfactory.opacclient.objects.Copy;
+import de.geeksfactory.opacclient.objects.SearchResult;
+import de.geeksfactory.opacclient.reminder.SyncAccountJob;
+import de.geeksfactory.opacclient.utils.DebugTools;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class CopiesAdapterTest {
+    private static MockedStatic<SyncAccountJob> mockSyncAccountJob;
+    private static MockedStatic<DebugTools> mockDebugTools;
+    private Context context;
+    private CopiesAdapter adapter;
+
+    @BeforeClass
+    public static void setUpClass() {
+        // avoid java.lang.IllegalStateException: WorkManager is not initialized properly.
+        mockSyncAccountJob = Mockito.mockStatic(SyncAccountJob.class);
+        // avoid java.io.IOException: socket not created
+        mockDebugTools = Mockito.mockStatic(DebugTools.class);
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        mockDebugTools.close();
+        mockSyncAccountJob.close();
+    }
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+    }
+
+    @Test
+    public void onCreateViewHolder() {
+        CopiesAdapter adapter = new CopiesAdapter(asList(new Copy()), context);
+        MockedStatic<LayoutInflater> mockStaticLayoutInflater = Mockito.mockStatic(LayoutInflater.class);
+        LayoutInflater mockLayoutInflater = mock(LayoutInflater.class);
+        ViewGroup mockParent = mock(ViewGroup.class);
+        View mockView = mock(View.class);
+
+        when(LayoutInflater.from(context)).thenReturn(mockLayoutInflater);
+        when(mockLayoutInflater.inflate(anyInt(), eq(mockParent), eq(false))).thenReturn(mockView);
+
+        CopiesAdapter.ViewHolder holder = adapter.onCreateViewHolder(mockParent, 0);
+        assertEquals(mockView, holder.itemView);
+
+        mockStaticLayoutInflater.close();
+    }
+
+    @Test
+    public void onBindViewHolder() {
+        LocalDate date = new LocalDate("2020-12-31");
+        Copy copy1 = new Copy();
+        copy1.setLocation("location");
+        copy1.setDepartment("department");
+        copy1.setBranch("branch");
+        copy1.setIssue("issue");
+        copy1.setStatus("status");
+        copy1.setStatusCode(SearchResult.Status.GREEN);
+        copy1.setReturnDate(date);
+        copy1.setReservations("reservations");
+        copy1.setShelfmark("shelfmark");
+        copy1.setUrl("url");
+        Copy copy2 = new Copy();
+        copy2.setStatusCode(SearchResult.Status.YELLOW);
+        copy2.setLocation("");
+        Copy copy3 = new Copy();
+        copy3.setStatusCode(SearchResult.Status.RED);
+        Copy copy4 = new Copy();
+        copy4.setStatusCode(SearchResult.Status.UNKNOWN);
+        Copy copy5 = new Copy();
+
+        adapter = new CopiesAdapter(asList(copy1, copy2, copy3, copy4, copy5), context);
+        LayoutInflater layoutInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        View view = layoutInflater.inflate(R.layout.listitem_copy, null, false);
+
+        CopiesAdapter.ViewHolder holder0 = new CopiesAdapter.ViewHolder(view);
+        adapter.onBindViewHolder(holder0, 0);
+        assertEquals("location", holder0.tvLocation.getText().toString());
+        assertEquals("department", holder0.tvDepartment.getText().toString());
+        assertEquals("branch", holder0.tvBranch.getText().toString());
+        assertEquals("issue", holder0.tvIssue.getText().toString());
+        assertEquals("status", holder0.tvStatus.getText().toString());
+        assertEquals(R.drawable.status_light_green_check, Shadows.shadowOf(holder0.tvStatus.getCompoundDrawables()[0]).getCreatedFromResId());
+        assertEquals(DateTimeFormat.shortDate().print(date), holder0.tvReturndate.getText().toString());
+        assertEquals("reservations", holder0.tvReservations.getText().toString());
+        assertEquals("shelfmark", holder0.tvShelfmark.getText().toString());
+        assertEquals("url", holder0.tvUrl.getText().toString());
+        assertEquals(View.VISIBLE, holder0.tvLocation.getVisibility());
+
+        CopiesAdapter.ViewHolder holder1 = new CopiesAdapter.ViewHolder(view);
+        adapter.onBindViewHolder(holder1, 1);
+        assertEquals(R.drawable.status_light_yellow_alert, Shadows.shadowOf(holder1.tvStatus.getCompoundDrawables()[0]).getCreatedFromResId());
+        assertEquals(View.GONE, holder1.tvLocation.getVisibility());
+
+        CopiesAdapter.ViewHolder holder2 = new CopiesAdapter.ViewHolder(view);
+        adapter.onBindViewHolder(holder2, 2);
+        assertEquals(R.drawable.status_light_red_cross, Shadows.shadowOf(holder2.tvStatus.getCompoundDrawables()[0]).getCreatedFromResId());
+        assertEquals(View.GONE, holder2.tvLocation.getVisibility());
+        assertEquals(View.GONE, holder2.tvReturndate.getVisibility());
+
+        CopiesAdapter.ViewHolder holder3 = new CopiesAdapter.ViewHolder(view);
+        adapter.onBindViewHolder(holder3, 3);
+        assertEquals(R.drawable.ic_status_24dp, Shadows.shadowOf(holder3.tvStatus.getCompoundDrawables()[0]).getCreatedFromResId());
+
+        CopiesAdapter.ViewHolder holder4 = new CopiesAdapter.ViewHolder(view);
+        adapter.onBindViewHolder(holder4, 4);
+        assertEquals(R.drawable.ic_status_24dp, Shadows.shadowOf(holder4.tvStatus.getCompoundDrawables()[0]).getCreatedFromResId());
+    }
+
+    @Test
+    public void itemCount() {
+        Copy copy = new Copy();
+        CopiesAdapter adapter = new CopiesAdapter(asList(copy), context);
+        assertEquals(1, adapter.getItemCount());
+    }
+}


### PR DESCRIPTION
Use same colored status markers as in search result list view to show availability status of individual copies in search result details:  

<img src="https://user-images.githubusercontent.com/19879328/104914399-5ec38780-598f-11eb-8115-e1ce393e2764.png" width="250">   

See #606 for discussions.