### PR TITLE
Fix scrolling issue

### DIFF
--- a/opacclient/opacapp/build.gradle
+++ b/opacclient/opacapp/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.work:work-runtime:2.3.4'
-    implementation 'com.google.android.material:material:1.2.0-rc01'
+    implementation 'com.google.android.material:material:1.3.0'
 
 // Other
     implementation 'io.sentry:sentry-android-core:2.2.0'


### PR DESCRIPTION
Searchresult detail fragment didn't scroll to end after device rotation. This was fixed by
https://github.com/material-components/material-components-android/commit/a21a30026a33fc20cf7ad699d32d1298b84096c6
in [release 1.3.0-alpha04](https://github.com/material-components/material-components-android/releases/tag/1.3.0-alpha04) of material components.

This resolves #605.