### PR TITLE
SLUB: Implementation of prolongMultiple

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
@@ -96,6 +96,7 @@ public interface StringProvider {
     String RESERVED = "reserved";
     String RENEWED = "renewed";
     String NOT_YET_RENEWABLE = "not_yet_renewable";
+    String RENEW_ILL_SEPARATELY = "renew_ill_separately";
 
     /**
      * Returns the translated string identified by identifier

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountFragment.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/AccountFragment.java
@@ -1365,6 +1365,7 @@ public class AccountFragment extends Fragment implements
                                            if (d != null) {
                                                d.cancel();
                                            }
+                                           invalidateData();
                                        }
                                    });
                 }
@@ -1530,6 +1531,7 @@ public class AccountFragment extends Fragment implements
                                            if (d != null) {
                                                d.cancel();
                                            }
+                                           invalidateData();
                                        }
                                    });
                 }

--- a/opacclient/opacapp/src/main/res/values-de/strings_api_errors.xml
+++ b/opacclient/opacapp/src/main/res/values-de/strings_api_errors.xml
@@ -97,4 +97,5 @@
   <string name="reserved">vorgemerkt</string>
   <string name="renewed">%dx verlängert</string>
   <string name="not_yet_renewable">noch nicht verlängerbar</string>
+  <string name="renew_ill_separately">Fernleihmedien bitte einzeln verlängern.</string>
 </resources>

--- a/opacclient/opacapp/src/main/res/values/strings_api_errors.xml
+++ b/opacclient/opacapp/src/main/res/values/strings_api_errors.xml
@@ -98,4 +98,5 @@
     <string name="reserved">reserved</string>
     <string name="renewed">%dx renewed</string>
     <string name="not_yet_renewable">not yet renewable</string>
+    <string name="renew_ill_separately">Please renew interlibrary loan items separately.</string>
 </resources>


### PR DESCRIPTION
This also fixes (second commit) a small bug that prevented account data update after a successful renewal without results list:

**Refresh data after prolongAll or prolongMultiple without results list**

prolongAll and prolongMultiple return a ProlongAllResult object that may or may not
contain a list of the individual success values. Some APIs (e.g. Koha or SLUB) don't
populate this results list (ProlongAllResult.results == null) and only provide a
general message (MultistepResult.message). In this case the account information was
not updated after a successful renewal. This PR forces data update after a successful
renewal even if the results list is null.