### PR TITLE
SLUB: get cover image uris

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
@@ -263,7 +263,17 @@ open class SLUB : OkHttpBaseApi() {
                     val key = with(it.optString("material") + it.optString("note") + it.optString("hostLabel")) {
                         if (isEmpty()) fieldCaptions[link] else this
                     }
-                    addDetail(Detail(key, it.optString("uri")))
+                    if (key == "Cover") {
+                        it.getString("uri").run {
+                            cover = if (startsWith("http://swbplus.bsz-bw.de/") && endsWith("cov.htm")) {
+                                replace(".htm", ".jpg")
+                            } else {
+                                this
+                            }
+                        }
+                    } else {
+                        addDetail(Detail(key, it.getString("uri")))
+                    }
                 }
             }
             // copies

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
@@ -275,6 +275,7 @@ class SLUBSearchTest : BaseHtmlTest() {
                 shelfmark = "ST 233 H939"
             })
             collectionId = "id/0-1183957874"
+            cover = "http://vub.de/cover/data/isbn:9783836240956/medium/true/de/vub/cover.jpg" // cover as "note"
         }
 
         val item = slub.parseResultById(json)
@@ -282,6 +283,20 @@ class SLUBSearchTest : BaseHtmlTest() {
         //details are in unspecified order, see https://stackoverflow.com/a/4920304/3944322
         assertThat(item, sameBeanAs(expected).ignoring("details"))
         assertThat(HashSet(item.details), sameBeanAs(HashSet(expected.details)))
+    }
+
+    @Test
+    fun testParseResultByIdCoverAsMaterial() {
+        val json = JSONObject(readResource("/slub/search/detaill-cover-jpg-as-material.json"))
+        val item = slub.parseResultById(json)
+        assertEquals("http://www.netread.com/jcusers2/bk1388/319/9781472533319/image/lgcover.9781472533319.jpg", item.cover)
+    }
+
+    @Test
+    fun testParseResultByIdCoverSWBPlus() {
+        val json = JSONObject(readResource("/slub/search/detail-with-cover-html-swbplus.json"))
+        val item = slub.parseResultById(json)
+        assertEquals("http://swbplus.bsz-bw.de/bsz352428775cov.jpg", item.cover)
     }
 
     @Test

--- a/opacclient/libopac/src/test/resources/slub/search/detail-with-cover-html-swbplus.json
+++ b/opacclient/libopac/src/test/resources/slub/search/detail-with-cover-html-swbplus.json
@@ -1,0 +1,68 @@
+{
+  "record": {
+    "format": "Buch",
+    "title": "Ivor Horton's beginning Java",
+    "contributor": [
+      "Horton, Ivor [Autor/In]"
+    ],
+    "publisher": [
+      "Indianapolis, Ind. Wiley 2011 "
+    ],
+    "ispartof": [],
+    "identifier": [
+      "9780470404140",
+      "0470404140"
+    ],
+    "language": [
+      "Englisch"
+    ],
+    "subject": [
+      "Java (Computer program language)"
+    ],
+    "description": "",
+    "status": "",
+    "rvk": ""
+  },
+  "id": "0-1613557620",
+  "oa": 0,
+  "thumbnail": "",
+  "links": [
+    {
+      "uri": "http://swbplus.bsz-bw.de/bsz352428775cov.htm",
+      "note": "",
+      "material": "Cover"
+    }
+  ],
+  "linksRelated": [
+    {
+      "uri": "http://swbplus.bsz-bw.de/bsz352428775cov.htm",
+      "hostLabel": "",
+      "note": "",
+      "material": "Cover"
+    }
+  ],
+  "linksAccess": [],
+  "linksGeneral": [],
+  "references": [],
+  "copies": [
+    {
+      "barcode": "32942813",
+      "location": "Bereichsbibliothek DrePunct",
+      "location_code": "zell9",
+      "sublocation": "Freihand",
+      "shelfmark": "ST 250 J35 H823(7)",
+      "mediatype": "B",
+      "3d": "ST 250 J35 H823(7)",
+      "3d_link": "https://3d.slub-dresden.de/viewer?project_id=3&search_key=ST%20250%20J35%20H823(7)&language=de&search_context1=zell9&search_context2=FH1&exemplar_id=32942813",
+      "issue": "",
+      "colorcode": "1",
+      "statusphrase": "Ausleihbar",
+      "link": "",
+      "status": "N",
+      "duedate": "",
+      "vormerken": "0",
+      "bestellen": "0"
+    }
+  ],
+  "parts": {}
+}

--- a/opacclient/libopac/src/test/resources/slub/search/detaill-cover-jpg-as-material.json
+++ b/opacclient/libopac/src/test/resources/slub/search/detaill-cover-jpg-as-material.json
@@ -1,0 +1,86 @@
+{
+  "record": {
+    "format": "Buch",
+    "title": "Photography and September 11th: spectacle, memory, trauma",
+    "contributor": [
+      "Good, Jennifer [Autor/In]"
+    ],
+    "publisher": [
+      "London [u.a.] Bloomsbury 2015 "
+    ],
+    "ispartof": [],
+    "identifier": [
+      "9781472533319",
+      "1472533313"
+    ],
+    "language": [
+      "Englisch"
+    ],
+    "subject": [
+      "Elfter September",
+      "Fotografie",
+      "Kollektives Gedächtnis",
+      "Trauma",
+      "Psychologie"
+    ],
+    "description": [
+      "&quot;It is all but impossible to think of September 11th 2001 and not, at the same time, recall an image. The overwhelmingly visual coverage in the world's media pictured a spectacle of terror, from images of the collapsing towers, to injured victims and fatigued firefighters. In the days, weeks and months that followed, this vast collection of photographs continued to circulate relentlessly. This book investigates the psychological impact of those photographs on a stunned American audience. Drawing on trauma theory, this book asks whether the prolonged exposure of audience to photographs was cathartic or damaging. It explores how first the collective memory of the event was established in the American psyche and then argues that through repetitive use of the most powerful pictures, the culture industry created a dangerously simple 9/11 metanarrative. At the same time, people began to reclaim and use photography to process their own feelings, most significantly in 'communities' of photographic memorial websites. Such exercises were widely perceived as democratic and an aid to recovery. This book interrogates that assumption, providing a new understanding of how audiences see and process news photography in times of crisis&quot;--",
+      "&quot;It is all but impossible to think of September 11th 2001 and not, at the same time, recall an image. The overwhelmingly visual coverage in the world's media pictured a spectacle of terror, from images of the collapsing towers, to injured victims and fatigued firefighters. In the days, weeks and months that followed, this vast collection of images continued to circulate relentlessly. This book investigates the psychological impact of those images on a stunned American audience. Drawing on trauma theory, this book asks whether the prolonged exposure of audience to images was cathartic or damaging. It explores how first the collective memory of the event was established in the American psyche and then argues that through repetitive use of the most powerful pictures, the culture industry created a dangerously simple 9/11 metanarrative. At the same time, people began to reclaim and use photography to process their own feelings, most significantly in 'communities' of photographic memorial websites. Such exercises were widely perceived as democratic and an aid to recovery. This book interrogates that assumption, providing a new understanding of how audiences see and process news photography in times of crisis&quot;--"
+    ],
+    "status": "",
+    "rvk": ""
+  },
+  "id": "0-81817546X",
+  "oa": 0,
+  "thumbnail": "",
+  "links": [
+    {
+      "uri": "http://www.netread.com/jcusers2/bk1388/319/9781472533319/image/lgcover.9781472533319.jpg",
+      "note": "",
+      "material": "Cover"
+    },
+    {
+      "uri": "http://swbplus.bsz-bw.de/bsz426082842inh.htm",
+      "note": "",
+      "material": "Inhaltsverzeichnis"
+    }
+  ],
+  "linksRelated": [
+    {
+      "uri": "http://www.netread.com/jcusers2/bk1388/319/9781472533319/image/lgcover.9781472533319.jpg",
+      "hostLabel": "",
+      "note": "",
+      "material": "Cover"
+    },
+    {
+      "uri": "http://swbplus.bsz-bw.de/bsz426082842inh.htm",
+      "hostLabel": "",
+      "note": "",
+      "material": "Inhaltsverzeichnis"
+    }
+  ],
+  "linksAccess": [],
+  "linksGeneral": [],
+  "references": [],
+  "copies": [
+    {
+      "barcode": "34616513",
+      "location": "Zentralbibliothek",
+      "location_code": "zell1",
+      "sublocation": "Freihand",
+      "shelfmark": "AP 95240 G646",
+      "mediatype": "B",
+      "3d": "AP 95240 G646",
+      "3d_link": "https://3d.slub-dresden.de/viewer?project_id=3&search_key=AP%2095240%20G646&language=de&search_context1=zell1&search_context2=FH1&exemplar_id=34616513",
+      "issue": "",
+      "colorcode": "1",
+      "statusphrase": "Ausleihbar",
+      "link": "",
+      "status": "N",
+      "duedate": "",
+      "vormerken": "0",
+      "bestellen": "0"
+    }
+  ],
+  "parts": {}
+}

--- a/opacclient/libopac/src/test/resources/slub/search/simple-item.json
+++ b/opacclient/libopac/src/test/resources/slub/search/simple-item.json
@@ -41,6 +41,12 @@
       "uri": "http://d-nb.info/970689268/04",
       "note": "",
       "material": "Inhaltsverzeichnis"
+    },
+    {
+      "uri": "http://vub.de/cover/data/isbn:9783836240956/medium/true/de/vub/cover.jpg",
+      "hostLabel": "",
+      "note": "Cover",
+      "material": ""
     }
   ],
   "linksRelated": [
@@ -49,6 +55,12 @@
       "hostLabel": "",
       "note": "",
       "material": "Inhaltsverzeichnis"
+    },
+    {
+      "uri": "http://vub.de/cover/data/isbn:9783836240956/medium/true/de/vub/cover.jpg",
+      "hostLabel": "",
+      "note": "Cover",
+      "material": ""
     }
   ],
   "linksAccess": [],


### PR DESCRIPTION
Set cover image uris for detailed items from links. With SLUB, many covers come from [SWBPlus](http://swbplus.bsz-bw.de/) where the htm file contains a cover image with the same name but ".jpg" extension.