### PR TITLE
Make links in copy views clickable

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/SLUB.kt
@@ -202,7 +202,18 @@ open class SLUB : OkHttpBaseApi() {
                         branch = it.getString("location")
                         department = Parser.unescapeEntities(it.getString("sublocation"), false)
                         shelfmark = it.getString("shelfmark")
-                        status = Jsoup.parse(it.getString("statusphrase")).text()
+                        it.getString("statusphrase").run {
+                            if (isNotEmpty()) {
+                                status = Parser.unescapeEntities(this, false)
+                            } else {
+                                it.getString("link").run {
+                                    if(isNotEmpty()){
+                                        status = stringProvider.getFormattedString(
+                                                StringProvider.INQUIRE_AVAILABILITY, this )
+                                    }
+                                }
+                            }
+                        }
                         statusCode = colorcodes.getOrElse(it.getString("colorcode")) { SearchResult.Status.UNKNOWN }
                         it.getString("duedate").run {
                             if (isNotEmpty()) {

--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/i18n/StringProvider.java
@@ -96,6 +96,7 @@ public interface StringProvider {
     String RESERVED = "reserved";
     String RENEWED = "renewed";
     String NOT_YET_RENEWABLE = "not_yet_renewable";
+    String INQUIRE_AVAILABILITY = "inquire_availability";
 
     /**
      * Returns the translated string identified by identifier

--- a/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
+++ b/opacclient/libopac/src/test/java/de/geeksfactory/opacclient/apis/SLUBTest.kt
@@ -205,6 +205,10 @@ class SLUBAccountTest : BaseHtmlTest() {
 class SLUBSearchTest : BaseHtmlTest() {
     private var slub = SLUB()
 
+    init {
+        slub.stringProvider = DummyStringProvider()
+    }
+
     @Test
     fun testParseEmptySearchResults() {
         val json = JSONObject(readResource("/slub/search/empty-search.json"))
@@ -280,6 +284,43 @@ class SLUBSearchTest : BaseHtmlTest() {
         val item = slub.parseResultById(json)
 
         //details are in unspecified order, see https://stackoverflow.com/a/4920304/3944322
+        assertThat(item, sameBeanAs(expected).ignoring("details"))
+        assertThat(HashSet(item.details), sameBeanAs(HashSet(expected.details)))
+    }
+
+    @Test
+    fun testParseResultByIdWithoutStatusphrase() {
+        val json = JSONObject(readResource("/slub/search/item_inquery_availability.json"))
+        val expected = DetailedItem().apply {
+            addDetail(Detail("Medientyp", "Buch"))
+            addDetail(Detail("Titel", "Astronomie: die kosmische Perspektive"))
+            title = "Astronomie: die kosmische Perspektive"
+            addDetail(Detail("Beteiligte",
+                    "Bennett, Jeffrey O. [Sonstige Person, Familie und Körperschaft]; Lesch, Harald [Hrsg.]"))
+            addDetail(Detail("Erschienen", "München [u.a.] Pearson 2010 "))
+            addDetail(Detail("Erschienen in", "Always learning"))
+            addDetail(Detail("ISBN", "9783827373601; 3827373603"))
+            addDetail(Detail("Sprache", "Deutsch; Englisch"))
+            addDetail(Detail("Schlagwörter", "Astronomie"))
+            addDetail(Detail("Beschreibung",
+                    "CD-ROM-Beil. enth.: Planetariumssoftware SkyGazer Educational-Edition; " +
+                    "Hier auch später erschienene, unveränderte Nachdrucke; " +
+                    "Auflagenzählung bezieht sich auf die engl. Orig.-Ausg"))
+            addDetail(Detail("Inhaltsverzeichnis", "http://d-nb.info/992365538/04"))
+            addDetail(Detail("Cover", "http://swbplus.bsz-bw.de/bsz304732311cov.htm"))
+            id = "id/0-590996231"
+            copies = arrayListOf(Copy().apply {
+                barcode = "34163775"
+                department = ""
+                branch = "Zentralbibliothek"
+                status = "inquire_availability https://tu-dresden.de/bu/umwelt/geo/ipg/astro"
+                statusCode = SearchResult.Status.UNKNOWN
+                shelfmark = "US 1020 B471(5)"
+            })
+        }
+
+        val item = slub.parseResultById(json)
+
         assertThat(item, sameBeanAs(expected).ignoring("details"))
         assertThat(HashSet(item.details), sameBeanAs(HashSet(expected.details)))
     }

--- a/opacclient/libopac/src/test/resources/slub/search/item_inquery_availability.json
+++ b/opacclient/libopac/src/test/resources/slub/search/item_inquery_availability.json
@@ -1,0 +1,89 @@
+{
+  "record": {
+    "format": "Buch",
+    "title": "Astronomie: die kosmische Perspektive",
+    "contributor": [
+      "Bennett, Jeffrey O. [Sonstige Person, Familie und Körperschaft]",
+      "Lesch, Harald [Hrsg.]"
+    ],
+    "publisher": [
+      "München [u.a.] Pearson 2010 "
+    ],
+    "ispartof": [
+      {
+        "title": "Always learning"
+      }
+    ],
+    "identifier": [
+      "9783827373601",
+      "3827373603"
+    ],
+    "language": [
+      "Deutsch",
+      "Englisch"
+    ],
+    "subject": [
+      "Astronomie"
+    ],
+    "description": [
+      "CD-ROM-Beil. enth.: Planetariumssoftware SkyGazer Educational-Edition",
+      "Hier auch sp&auml;ter erschienene, unver&auml;nderte Nachdrucke",
+      "Auflagenz&auml;hlung bezieht sich auf die engl. Orig.-Ausg"
+    ],
+    "status": "",
+    "rvk": ""
+  },
+  "id": "0-590996231",
+  "oa": 0,
+  "thumbnail": "",
+  "links": [
+    {
+      "uri": "http://d-nb.info/992365538/04",
+      "note": "",
+      "material": "Inhaltsverzeichnis"
+    },
+    {
+      "uri": "http://swbplus.bsz-bw.de/bsz304732311cov.htm",
+      "note": "",
+      "material": "Cover"
+    }
+  ],
+  "linksRelated": [
+    {
+      "uri": "http://d-nb.info/992365538/04",
+      "hostLabel": "",
+      "note": "",
+      "material": "Inhaltsverzeichnis"
+    },
+    {
+      "uri": "http://swbplus.bsz-bw.de/bsz304732311cov.htm",
+      "hostLabel": "",
+      "note": "",
+      "material": "Cover"
+    }
+  ],
+  "linksAccess": [],
+  "linksGeneral": [],
+  "references": [],
+  "copies": [
+    {
+      "barcode": "34163775",
+      "location": "Zentralbibliothek",
+      "location_code": "zell1",
+      "sublocation": "",
+      "shelfmark": "US 1020 B471(5)",
+      "mediatype": "B",
+      "3d": "",
+      "3d_link": "",
+      "issue": "",
+      "colorcode": "0",
+      "statusphrase": "",
+      "link": "https://tu-dresden.de/bu/umwelt/geo/ipg/astro",
+      "status": "H",
+      "duedate": "",
+      "vormerken": "0",
+      "bestellen": "0"
+    }
+  ],
+  "parts": {}
+}

--- a/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
+++ b/opacclient/opacapp/src/main/java/de/geeksfactory/opacclient/frontend/CopiesAdapter.java
@@ -1,6 +1,8 @@
 package de.geeksfactory.opacclient.frontend;
 
 import android.content.Context;
+import android.text.Html;
+import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -67,7 +69,8 @@ public class CopiesAdapter extends RecyclerView.Adapter<CopiesAdapter.ViewHolder
 
     private void setTextOrHide(String text, TextView tv) {
         if (notEmpty(text)) {
-            tv.setText(text);
+            tv.setText(Html.fromHtml(text));
+            tv.setMovementMethod(LinkMovementMethod.getInstance());
             tv.setVisibility(View.VISIBLE);
         } else {
             tv.setVisibility(View.GONE);

--- a/opacclient/opacapp/src/main/res/values-de/strings_api_errors.xml
+++ b/opacclient/opacapp/src/main/res/values-de/strings_api_errors.xml
@@ -97,4 +97,5 @@
   <string name="reserved">vorgemerkt</string>
   <string name="renewed">%dx verlängert</string>
   <string name="not_yet_renewable">noch nicht verlängerbar</string>
+  <string name="inquire_availability">Verfügbarkeit bitte &lt;a href="%s">hier&lt;/a> erfragen</string>
 </resources>

--- a/opacclient/opacapp/src/main/res/values/strings_api_errors.xml
+++ b/opacclient/opacapp/src/main/res/values/strings_api_errors.xml
@@ -98,4 +98,5 @@
     <string name="reserved">reserved</string>
     <string name="renewed">%dx renewed</string>
     <string name="not_yet_renewable">not yet renewable</string>
+    <string name="inquire_availability">Please inquire about availability &lt;a href="%s">here&lt;/a></string>
 </resources>

--- a/opacclient/opacapp/src/test/java/de/geeksfactory/opacclient/frontend/CopiesAdapterTest.java
+++ b/opacclient/opacapp/src/test/java/de/geeksfactory/opacclient/frontend/CopiesAdapterTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 
 import de.geeksfactory.opacclient.R;


### PR DESCRIPTION
Needed for SLUB where copy status may be empty and a link is provided
to the institute/chair where this book might be available.
(prior to Jan 2021 the link was provided in the status field e.g. as
"Verfügbarkeit bitte in \<a href="...">Professur für ...\</a> erfragen")
See also https://stackoverflow.com/a/20647011/3944322.

See also second item/commit of #606.