### PR TITLE
Fix Adis Stuttgart Stadtbücherei 2022-05

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Adis.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/Adis.java
@@ -223,6 +223,7 @@ public class Adis extends OkHttpBaseApi implements OpacApi {
             if (!accountFormOldstyle) {
                 List<NameValuePair> nvpairs_a = new ArrayList(s_pageform);
                 nvpairs_a.add(new BasicNameValuePair("$ScriptButton_hidden", "BK"));
+                nvpairs_a.add(new BasicNameValuePair("selected", "ZTEXT       *SBK"));
                 accountFormBody = nvpairs_a;
             }
 


### PR DESCRIPTION
Die Stadtbücherei in Stuttgart hat Ende Mai den Einstieg in ihre Webseite etwas umgebaut, so dass in WebOpac die Abfrage der Suchfelder, die Suche und Kontoabfrage nicht mehr funktionieren.  Folgender Fix korrigiert den Fehler. 

Auch der Serveralias wurde von opac.sbs.stuttgart.de nach stadtbibliothek-stuttgart.de geändert. Also 
"baseurl": "https://stadtbibliothek-stuttgart.de/aDISWeb/app"