### PR TITLE
Fix the date regex for Pica LBS

### DIFF
--- a/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/PicaLBS.java
+++ b/opacclient/libopac/src/main/java/de/geeksfactory/opacclient/apis/PicaLBS.java
@@ -266,7 +266,7 @@ public class PicaLBS extends Pica {
 
     private static LocalDate parseDate(String date) {
         try {
-            if (date.matches("\\d\\d.\\d\\d.\\d\\d\\d\\d")) {
+            if (date.matches("\\d\\d\\.\\d\\d\\.\\d\\d\\d\\d")) {
                 return DateTimeFormat.forPattern("dd.MM.yyyy").withLocale(Locale.GERMAN)
                         .parseLocalDate(date);
             } else if (date.matches("\\d\\d/\\d\\d/\\d\\d\\d\\d")) {


### PR DESCRIPTION
The dot would match any character, including the "/" for english style dates, so the parser would incorrectly assume that the german style date format was used, causing the date format parser to fail.